### PR TITLE
ci: add GitHub Actions for CI and automated releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,92 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  code-quality:
+    name: Code Quality (PHP 8.0)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+          extensions: dom, curl, libxml, mbstring, zip, gd
+          tools: composer:v2
+          coverage: none
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: Run PHPCS
+        run: composer phpcs
+
+      - name: Run PHPStan
+        run: composer phpstan
+
+  tests:
+    name: Tests (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+    needs: code-quality
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.0', '8.1', '8.2', '8.3']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, gd
+          tools: composer:v2
+          coverage: none
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-php${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-php${{ matrix.php }}-
+            ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: Run PHPUnit
+        run: composer test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,189 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG_NAME#v}"
+          echo "tag=${TAG_NAME}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Extracted version: ${VERSION} from tag: ${TAG_NAME}"
+
+      - name: Validate semver format
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          # Composer-compatible version regex (matches build script)
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(stable|beta|b|rc|alpha|a|patch|pl|p|dev)[0-9]*)?$ ]]; then
+            echo "Error: Invalid version format '${VERSION}'"
+            echo "Valid examples: 1.0.0, 1.0.0-beta, 1.0.0-beta1, 1.0.0-rc1, 1.0.0-alpha, 1.0.0-dev"
+            exit 1
+          fi
+          echo "Version format is valid: ${VERSION}"
+
+      - name: Verify version in plugin files
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          ERRORS=0
+
+          # Check Version header in plugin file
+          PLUGIN_HEADER_VERSION=$(grep -E "^\s*\*\s*Version:" ihumbak-invoices.php | sed 's/.*Version:\s*//' | tr -d '[:space:]')
+          if [[ "$PLUGIN_HEADER_VERSION" != "$VERSION" ]]; then
+            echo "Warning: Version header mismatch - expected '${VERSION}', found '${PLUGIN_HEADER_VERSION}'"
+            ERRORS=$((ERRORS + 1))
+          else
+            echo "Version header matches: ${PLUGIN_HEADER_VERSION}"
+          fi
+
+          # Check IHUMBAK_INVOICES_VERSION constant
+          CONSTANT_VERSION=$(grep "IHUMBAK_INVOICES_VERSION" ihumbak-invoices.php | sed "s/.*'\([^']*\)'.*/\1/")
+          if [[ "$CONSTANT_VERSION" != "$VERSION" ]]; then
+            echo "Warning: IHUMBAK_INVOICES_VERSION mismatch - expected '${VERSION}', found '${CONSTANT_VERSION}'"
+            ERRORS=$((ERRORS + 1))
+          else
+            echo "IHUMBAK_INVOICES_VERSION matches: ${CONSTANT_VERSION}"
+          fi
+
+          # Check composer.json version
+          COMPOSER_VERSION=$(grep '"version"' composer.json | sed 's/.*"version":\s*"\([^"]*\)".*/\1/')
+          if [[ "$COMPOSER_VERSION" != "$VERSION" ]]; then
+            echo "Warning: composer.json version mismatch - expected '${VERSION}', found '${COMPOSER_VERSION}'"
+            ERRORS=$((ERRORS + 1))
+          else
+            echo "composer.json version matches: ${COMPOSER_VERSION}"
+          fi
+
+          if [[ $ERRORS -gt 0 ]]; then
+            echo ""
+            echo "Warning: ${ERRORS} version mismatch(es) found. Proceeding with build anyway."
+            echo "Please update version numbers before the next release."
+          fi
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+          extensions: dom, curl, libxml, mbstring, zip, gd
+          tools: composer:v2
+          coverage: none
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-release-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-release-
+            ${{ runner.os }}-composer-
+
+      - name: Install production dependencies
+        run: composer install --no-dev --optimize-autoloader --no-progress --no-interaction
+
+      - name: Build release ZIP
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          PLUGIN_SLUG="ihumbak-invoices"
+          BUILD_DIR="build"
+          ZIP_NAME="${PLUGIN_SLUG}-${VERSION}.zip"
+
+          # Create build directory
+          mkdir -p "${BUILD_DIR}/${PLUGIN_SLUG}"
+
+          # Copy files using rsync with exclusions (matching build-release.sh)
+          rsync -a \
+            --exclude='.git' \
+            --exclude='.gitignore' \
+            --exclude='.gitattributes' \
+            --exclude='.editorconfig' \
+            --exclude='.phpcs.xml' \
+            --exclude='.phpunit.result.cache' \
+            --exclude='.claude' \
+            --exclude='phpcs.xml' \
+            --exclude='phpstan.neon' \
+            --exclude='phpunit.xml' \
+            --exclude='composer.lock' \
+            --exclude='CLAUDE.md' \
+            --exclude='PLAN.md' \
+            --exclude='tests' \
+            --exclude='scripts' \
+            --exclude='stubs' \
+            --exclude='docs' \
+            --exclude='build' \
+            --exclude='dist' \
+            --exclude='node_modules' \
+            --exclude='.github' \
+            --exclude='.vscode' \
+            --exclude='.idea' \
+            --exclude='*.log' \
+            --exclude='*.cache' \
+            ./ "${BUILD_DIR}/${PLUGIN_SLUG}/"
+
+          # Create ZIP file
+          cd "${BUILD_DIR}"
+          zip -r "../${ZIP_NAME}" "${PLUGIN_SLUG}"
+          cd ..
+
+          # Show ZIP info
+          echo "Created: ${ZIP_NAME}"
+          ls -lh "${ZIP_NAME}"
+
+          # Set output for next steps
+          echo "zip_name=${ZIP_NAME}" >> $GITHUB_ENV
+
+      - name: Determine pre-release status
+        id: prerelease
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if [[ "$VERSION" =~ (alpha|beta|rc|dev) ]]; then
+            echo "is_prerelease=true" >> $GITHUB_OUTPUT
+            echo "Version ${VERSION} is a pre-release"
+          else
+            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+            echo "Version ${VERSION} is a stable release"
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ env.zip_name }}
+          name: v${{ steps.version.outputs.version }}
+          tag_name: ${{ steps.version.outputs.tag }}
+          prerelease: ${{ steps.prerelease.outputs.is_prerelease }}
+          generate_release_notes: true
+          body: |
+            ## iHumbak WooCommerce Invoices v${{ steps.version.outputs.version }}
+
+            ### Installation
+
+            1. Download `${{ env.zip_name }}` from the assets below
+            2. Go to WordPress Admin > Plugins > Add New > Upload Plugin
+            3. Upload the ZIP file and click "Install Now"
+            4. Activate the plugin
+
+            ### Requirements
+
+            - PHP 8.0+
+            - WordPress 6.0+
+            - WooCommerce 7.0+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -41,6 +41,7 @@ EXCLUDE_FILES=(
     "phpunit.xml"
     "composer.lock"
     "CLAUDE.md"
+    "PLAN.md"
     "tests"
     "scripts"
     "stubs"


### PR DESCRIPTION
## Summary

- Add CI workflow (`ci.yml`) - runs on push/PR to `develop`
- Add Release workflow (`release.yml`) - triggers on version tag push (`v*`)

## Changes

### CI Workflow
- PHPCS and PHPStan checks (PHP 8.0)
- PHPUnit tests with matrix (PHP 8.0, 8.1, 8.2, 8.3)
- Composer dependency caching
- Concurrency control (cancels outdated runs)

### Release Workflow
- Extracts and validates semver from tag
- Verifies version in plugin files
- Builds production ZIP (excludes dev files)
- Creates GitHub Release with ZIP attached
- Auto-detects pre-releases (alpha/beta/rc/dev)

## Test plan

- [ ] Push to `develop` → CI workflow runs
- [ ] Create PR to `develop` → CI workflow runs
- [ ] Create tag `v0.5.0-test` → Release workflow creates GitHub Release
- [ ] Downloaded ZIP installs correctly in WordPress

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)