### PR TITLE
fix(receipt): save payment method fields for all document types

### DIFF
--- a/src/Infrastructure/Database/DocumentRepository.php
+++ b/src/Infrastructure/Database/DocumentRepository.php
@@ -333,14 +333,10 @@ class DocumentRepository {
 			'pdf_path'              => $document->getPdfPath(),
 			'notes'                 => $document->getNotes(),
 			'sent_at'               => $document->getSentAt()?->format( 'Y-m-d H:i:s' ),
+			'payment_method'        => $document->getPaymentMethod(),
+			'payment_method_id'     => $document->getPaymentMethodId(),
+			'payment_method_title'  => $document->getPaymentMethodTitle(),
 		);
-
-		// Add invoice specific fields.
-		if ( $document instanceof Invoice ) {
-			$data['payment_method']       = $document->getPaymentMethod();
-			$data['payment_method_id']    = $document->getPaymentMethodId();
-			$data['payment_method_title'] = $document->getPaymentMethodTitle();
-		}
 
 		// Add credit note specific fields.
 		if ( $document instanceof CreditNote ) {


### PR DESCRIPTION
## Summary

- Fixed bug where payment method fields were not persisted when saving a Receipt
- Payment method data was correctly fetched from order during creation but lost after save
- Root cause: `DocumentRepository::prepareData()` only included payment method fields for `Invoice` instances

## Changes

Moved `payment_method`, `payment_method_id`, and `payment_method_title` from Invoice-specific block to base data array in `DocumentRepository::prepareData()`.

## Test plan

- [ ] Create a receipt from an order with payment method
- [ ] Verify payment method fields are displayed during edit
- [ ] Save the receipt
- [ ] Re-open the receipt and verify payment method fields are still populated
- [ ] Verify invoices still save payment method correctly

Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)