### PR TITLE
fix(items): require VAT rate and set correct default quantity for returns

### DIFF
--- a/assets/js/document-edit.js
+++ b/assets/js/document-edit.js
@@ -209,29 +209,49 @@
 
         /**
          * Validate items before form submission.
-         * Checks that all items with values have a name.
+         * Checks that all items have a name and VAT rate.
          *
          * @return {boolean} True if valid, false otherwise.
          */
         validateItems: function() {
-            var hasError = false;
+            var hasNameError = false;
+            var hasVatError = false;
 
             $('#ihumbak-items-body .ihumbak-item-row-name').each(function() {
                 var $row = $(this);
+                var index = $row.data('index');
                 var $nameInput = $row.find('.item-name');
                 var name = $.trim($nameInput.val());
 
                 // Every item row must have a name (after trim).
                 if (name === '') {
-                    hasError = true;
+                    hasNameError = true;
                     $nameInput.addClass('ihumbak-input-error');
                 } else {
                     $nameInput.removeClass('ihumbak-input-error');
                 }
+
+                // Get the corresponding values row to check VAT rate.
+                var $valuesRow = $('#ihumbak-items-body .ihumbak-item-row-values[data-index="' + index + '"]');
+                var $vatInput = $valuesRow.find('.item-tax-rate');
+                var vatValue = $.trim($vatInput.val());
+
+                // VAT rate must be specified (empty string is not allowed, but 0 is valid).
+                if (vatValue === '') {
+                    hasVatError = true;
+                    $vatInput.addClass('ihumbak-input-error');
+                } else {
+                    $vatInput.removeClass('ihumbak-input-error');
+                }
             });
 
-            if (hasError) {
-                alert(ihumbakInvoices.i18n.nameRequiredError || 'Please enter a product name for all items.');
+            if (hasNameError) {
+                this.showNotice('error', ihumbakInvoices.i18n.nameRequiredError || 'Please enter a product name for all items.');
+                return false;
+            }
+
+            if (hasVatError) {
+                this.showNotice('error', ihumbakInvoices.i18n.vatRequiredError || 'Please enter a VAT rate for all items.');
                 return false;
             }
 
@@ -314,7 +334,7 @@
                     quantity: parseFloat($valuesRow.find('.item-quantity').val()) || 1,
                     unit: $nameRow.find('.item-unit').val() || 'pcs',
                     unit_price_net: parseFloat($valuesRow.find('.item-price-net').val()) || 0,
-                    tax_rate: parseFloat($valuesRow.find('.item-tax-rate').val()) || 23,
+                    tax_rate: parseFloat($valuesRow.find('.item-tax-rate').val()) || 0,
                     price_type: 'net'
                 });
             });
@@ -562,7 +582,8 @@
             $rows.find('.item-quantity').val(itemData.quantity || 1);
             $rows.find('.item-unit').val(itemData.unit || 'pcs');
             $rows.find('.item-price-net').val((itemData.unit_price_net || 0).toFixed(2));
-            $rows.find('.item-tax-rate').val(itemData.tax_rate || 23);
+            // Use provided tax_rate (including 0 for VAT-exempt), or leave empty if not provided.
+            $rows.find('.item-tax-rate').val(itemData.tax_rate !== undefined && itemData.tax_rate !== null ? itemData.tax_rate : '');
             $rows.find('.item-price-gross').val((itemData.unit_price_gross || 0).toFixed(2));
             $rows.find('.item-total-net').val((itemData.line_total_net || 0).toFixed(2));
             $rows.find('.item-tax-amount').val((itemData.tax_amount || 0).toFixed(2));
@@ -1247,7 +1268,7 @@
                         name: item.name,
                         quantity: -Math.abs(item.quantity || 1),
                         unit_price_net: item.unit_price_net || 0,
-                        tax_rate: 23 // Default, will be recalculated.
+                        tax_rate: item.tax_rate // Use tax_rate from refund data or leave empty.
                     });
                 });
             }

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -421,6 +421,7 @@ final class Plugin {
 					'orderNotFound'          => __( 'Order not found.', 'ihumbak-invoices' ),
 					'replaceItemsConfirm'    => __( 'The form already contains items. Do you want to replace them with order data?', 'ihumbak-invoices' ),
 					'nameRequiredError'      => __( 'Please enter a product name for all items with values.', 'ihumbak-invoices' ),
+					'vatRequiredError'       => __( 'Please enter a VAT rate for all items.', 'ihumbak-invoices' ),
 					'selectOriginalDocument' => __( 'Please select the original document to correct.', 'ihumbak-invoices' ),
 				),
 			)

--- a/src/Modules/Admin/DocumentController.php
+++ b/src/Modules/Admin/DocumentController.php
@@ -772,6 +772,7 @@ class DocumentController {
 	 * Get document items from request.
 	 *
 	 * @return DocumentItem[]
+	 * @throws \InvalidArgumentException When VAT rate is missing for any item.
 	 */
 	private function get_items_from_request(): array {
 		// phpcs:disable WordPress.Security.NonceVerification.Missing -- Nonce verified in calling method.
@@ -795,6 +796,13 @@ class DocumentController {
 				continue;
 			}
 
+			// Validate that tax_rate is provided (0 is valid, but empty string is not).
+			if ( ! isset( $item_data['tax_rate'] ) || '' === trim( (string) $item_data['tax_rate'] ) ) {
+				throw new \InvalidArgumentException(
+					esc_html__( 'Please enter a VAT rate for all items.', 'ihumbak-invoices' )
+				);
+			}
+
 			$item = new DocumentItem();
 			$item->setName( $name );
 			$item->setSku( sanitize_text_field( $item_data['sku'] ?? '' ) );
@@ -802,7 +810,7 @@ class DocumentController {
 			$item->setUnit( sanitize_text_field( $item_data['unit'] ?? 'szt.' ) );
 			$item->setUnitPriceNet( (float) ( $item_data['unit_price_net'] ?? 0 ) );
 			$item->setUnitPriceGross( (float) ( $item_data['unit_price_gross'] ?? 0 ) );
-			$item->setTaxRate( (float) ( $item_data['tax_rate'] ?? 23 ) );
+			$item->setTaxRate( (float) $item_data['tax_rate'] );
 			$item->setTaxAmount( (float) ( $item_data['tax_amount'] ?? 0 ) );
 			$item->setLineTotalNet( (float) ( $item_data['line_total_net'] ?? 0 ) );
 			$item->setLineTotalGross( (float) ( $item_data['line_total_gross'] ?? 0 ) );
@@ -814,7 +822,7 @@ class DocumentController {
 			$items[] = $item;
 		}
 
-        // phpcs:enable WordPress.Security.NonceVerification.Missing
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
 
 		return $items;
 	}

--- a/templates/admin/partials/items-table.php
+++ b/templates/admin/partials/items-table.php
@@ -87,8 +87,8 @@ $readonly_class          = $can_edit ? '' : ' ihumbak-readonly';
 						</td>
 						<td class="column-tax-rate">
 							<input type="number" name="items[<?php echo esc_attr( $index ); ?>][tax_rate]"
-									value="<?php echo esc_attr( $item['tax_rate'] ?? 23 ); ?>"
-									class="item-tax-rate" step="0.01" min="0" max="100" placeholder="23" <?php wp_readonly( ! $can_edit ); ?>>
+									value="<?php echo esc_attr( $item['tax_rate'] ?? '' ); ?>"
+									class="item-tax-rate" step="0.01" min="0" max="100" placeholder="<?php esc_attr_e( 'VAT %', 'ihumbak-invoices' ); ?>" required <?php wp_readonly( ! $can_edit ); ?>>
 						</td>
 						<td class="column-total-net">
 							<span class="item-total-net-display"><?php echo esc_html( number_format( (float) ( $item['line_total_net'] ?? 0 ), 2, ',', ' ' ) ); ?></span>
@@ -170,7 +170,7 @@ $readonly_class          = $can_edit ? '' : ' ihumbak-readonly';
 			<input type="number" name="items[{{index}}][unit_price_net]" value="" class="item-price-net" step="0.01" min="0" placeholder="0.00">
 		</td>
 		<td class="column-tax-rate">
-			<input type="number" name="items[{{index}}][tax_rate]" value="23" class="item-tax-rate" step="0.01" min="0" max="100" placeholder="23">
+			<input type="number" name="items[{{index}}][tax_rate]" value="" class="item-tax-rate" step="0.01" min="0" max="100" placeholder="<?php esc_attr_e( 'VAT %', 'ihumbak-invoices' ); ?>" required>
 		</td>
 		<td class="column-total-net">
 			<span class="item-total-net-display">0,00</span>

--- a/templates/admin/partials/items-table.php
+++ b/templates/admin/partials/items-table.php
@@ -15,6 +15,7 @@ $items                   = $items ?? array();
 $allow_negative_quantity = $allow_negative_quantity ?? false;
 $can_edit                = $can_edit ?? true;
 $quantity_min_attr       = $allow_negative_quantity ? '' : ' min="0.001"';
+$default_quantity        = $allow_negative_quantity ? -1 : 1;
 $readonly_class          = $can_edit ? '' : ' ihumbak-readonly';
 ?>
 
@@ -163,7 +164,7 @@ $readonly_class          = $can_edit ? '' : ' ihumbak-readonly';
 			<input type="text" name="items[{{index}}][sku]" value="" class="item-sku" placeholder="<?php esc_attr_e( 'SKU', 'ihumbak-invoices' ); ?>">
 		</td>
 		<td class="column-quantity">
-			<input type="number" name="items[{{index}}][quantity]" value="1" class="item-quantity" step="0.001" placeholder="1"<?php echo esc_attr( $quantity_min_attr ); ?> required>
+			<input type="number" name="items[{{index}}][quantity]" value="<?php echo esc_attr( $default_quantity ); ?>" class="item-quantity" step="0.001" placeholder="<?php echo esc_attr( $default_quantity ); ?>"<?php echo esc_attr( $quantity_min_attr ); ?> required>
 		</td>
 		<td class="column-price-net">
 			<input type="number" name="items[{{index}}][unit_price_net]" value="" class="item-price-net" step="0.01" min="0" placeholder="0.00">


### PR DESCRIPTION
## Summary
- Set default quantity to -1 for return/credit note documents instead of 1
- Require VAT rate for all items - removed default 23% assumption
- Add frontend and backend validation for VAT rate field
- Preserve original VAT rate when loading refund data into items

## Test plan
- [ ] Create a new return document and verify default quantity is -1
- [ ] Add item without VAT rate and verify validation error appears
- [ ] Add item with VAT rate 0 (exempt) and verify it saves correctly
- [ ] Load refund data and verify VAT rates are preserved from original order


🤖 Generated with [Claude Code](https://claude.com/claude-code)