### PR TITLE
fix(invoice): use discounted prices on documents

### DIFF
--- a/src/Modules/Invoice/OrderDataExtractor.php
+++ b/src/Modules/Invoice/OrderDataExtractor.php
@@ -115,9 +115,9 @@ class OrderDataExtractor {
 			$quantity = 1.0;
 		}
 
-		// Get line totals from WooCommerce (these are net values).
-		$line_total_net = (float) $item->get_subtotal();
-		$tax_amount     = (float) $item->get_subtotal_tax();
+		// Get line totals from WooCommerce (net values after discounts).
+		$line_total_net = (float) $item->get_total();
+		$tax_amount     = (float) $item->get_total_tax();
 
 		// Calculate unit price net.
 		$unit_price_net = $line_total_net / $quantity;

--- a/tests/Unit/Modules/Invoice/OrderDataExtractorTest.php
+++ b/tests/Unit/Modules/Invoice/OrderDataExtractorTest.php
@@ -948,6 +948,100 @@ class OrderDataExtractorTest extends TestCase {
 	}
 
 	// =========================================================================
+	// Tests for discounted items (issue #9)
+	// =========================================================================
+
+	/**
+	 * Test extracting items uses prices after discount (get_total instead of get_subtotal).
+	 *
+	 * This test verifies fix for issue #9: Product prices on invoices
+	 * should reflect applied discounts, not original prices.
+	 */
+	public function test_extract_items_uses_discounted_prices(): void {
+		$order = $this->createOrder();
+
+		$product = $this->createProduct( 'SKU-DISCOUNT' );
+		// Item with 20% discount applied:
+		// Original: 100.00 net, 23.00 tax (subtotal)
+		// After discount: 80.00 net, 18.40 tax (total).
+		$item = $this->createOrderItem(
+			array(
+				'product_id'   => 1,
+				'name'         => 'Discounted Product',
+				'quantity'     => 1,
+				'subtotal'     => '100.00',
+				'subtotal_tax' => '23.00',
+				'total'        => '80.00',
+				'total_tax'    => '18.40',
+			),
+			$product
+		);
+		$order->add_item( $item );
+
+		$result = $this->extractor->extractItems( $order );
+
+		// Should use discounted values (total), not original (subtotal).
+		$this->assertEquals( 80.00, $result[0]['unit_price_net'] );
+		$this->assertEquals( 98.40, $result[0]['unit_price_gross'] );
+		$this->assertEquals( 23.0, $result[0]['tax_rate'] );
+		$this->assertEquals( 18.40, $result[0]['tax_amount'] );
+		$this->assertEquals( 80.00, $result[0]['line_total_net'] );
+		$this->assertEquals( 98.40, $result[0]['line_total_gross'] );
+	}
+
+	/**
+	 * Test extracting multiple items with different discount percentages.
+	 *
+	 * Verifies that each item's discounted price is correctly calculated.
+	 */
+	public function test_extract_items_with_multiple_discounts(): void {
+		$order = $this->createOrder();
+
+		// Item 1: 10% discount (100 -> 90).
+		$product1 = $this->createProduct( 'SKU-001' );
+		$item1    = $this->createOrderItem(
+			array(
+				'product_id'   => 1,
+				'name'         => 'Product with 10% discount',
+				'quantity'     => 2,
+				'subtotal'     => '200.00',
+				'subtotal_tax' => '46.00',
+				'total'        => '180.00',
+				'total_tax'    => '41.40',
+			),
+			$product1
+		);
+
+		// Item 2: 50% discount (50 -> 25).
+		$product2 = $this->createProduct( 'SKU-002' );
+		$item2    = $this->createOrderItem(
+			array(
+				'product_id'   => 2,
+				'name'         => 'Product with 50% discount',
+				'quantity'     => 1,
+				'subtotal'     => '50.00',
+				'subtotal_tax' => '11.50',
+				'total'        => '25.00',
+				'total_tax'    => '5.75',
+			),
+			$product2
+		);
+
+		$order->add_item( $item1 );
+		$order->add_item( $item2 );
+
+		$result = $this->extractor->extractItems( $order );
+
+		// Item 1: 180 / 2 = 90 per unit.
+		$this->assertEquals( 90.00, $result[0]['unit_price_net'] );
+		$this->assertEquals( 180.00, $result[0]['line_total_net'] );
+
+		// Item 2: 25 / 1 = 25 per unit.
+		$this->assertEquals( 25.00, $result[1]['unit_price_net'] );
+		$this->assertEquals( 25.00, $result[1]['line_total_net'] );
+	}
+
+	// =========================================================================
 	// Tests for extractPaymentDate()
 	// =========================================================================
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -656,6 +656,28 @@ if ( ! class_exists( 'WC_Order_Item_Product' ) ) {
         }
 
         /**
+         * Get total (after discounts).
+         *
+         * Falls back to subtotal if total is not set (for backward compatibility).
+         *
+         * @return string
+         */
+        public function get_total(): string {
+            return (string) ( $this->data['total'] ?? $this->data['subtotal'] ?? '0' );
+        }
+
+        /**
+         * Get total tax (after discounts).
+         *
+         * Falls back to subtotal_tax if total_tax is not set (for backward compatibility).
+         *
+         * @return string
+         */
+        public function get_total_tax(): string {
+            return (string) ( $this->data['total_tax'] ?? $this->data['subtotal_tax'] ?? '0' );
+        }
+
+        /**
          * Get product ID.
          *
          * @return int


### PR DESCRIPTION
## Summary

- Fix issue where product prices on invoices showed original prices instead of discounted prices
- Change `OrderDataExtractor` to use `get_total()` and `get_total_tax()` instead of `get_subtotal()` and `get_subtotal_tax()`
- Add mock methods `get_total()` and `get_total_tax()` to test bootstrap for discount testing

## Test plan

- [x] All 432 tests pass
- [x] PHPCS: No errors
- [x] PHPStan: No errors
- [ ] Manual test: Create order with discount code, generate invoice, verify prices reflect discount

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)