### PR TITLE
fix(email): fix receipt return email and enable sending for manual documents

### DIFF
--- a/src/Modules/Admin/DocumentListTable.php
+++ b/src/Modules/Admin/DocumentListTable.php
@@ -223,8 +223,10 @@ class DocumentListTable extends \WP_List_Table {
 				esc_html__( 'Regenerate PDF', 'ihumbak-invoices' )
 			);
 
-			// Add send email action for issued documents with linked order (not for already sent).
-			if ( $item->getOrderId() && ! $item->wasSent() ) {
+			// Add send email action for issued documents with email recipient available.
+			// Show when document has linked order OR buyer email (for manual documents).
+			$has_buyer_email = $item->getBuyer() && $item->getBuyer()->getEmail();
+			if ( ( $item->getOrderId() || $has_buyer_email ) && ! $item->wasSent() ) {
 				$email_url = add_query_arg(
 					array(
 						'page'   => 'ihumbak-invoices',

--- a/src/Modules/Email/EmailService.php
+++ b/src/Modules/Email/EmailService.php
@@ -163,32 +163,44 @@ class EmailService {
 	/**
 	 * Get recipient email address for document.
 	 *
-	 * Uses billing email from the linked WooCommerce order.
+	 * Uses billing email from the linked WooCommerce order, or falls back
+	 * to the buyer email when no order is linked (for manual documents).
 	 *
 	 * @param Document $document The document.
 	 * @return string|null Recipient email or null if not found.
 	 */
 	public function getRecipientEmail( Document $document ): ?string {
 		$order_id = $document->getOrderId();
+		$order    = null;
+		$email    = null;
 
-		if ( ! $order_id ) {
-			return null;
+		// Try to get email from linked order first.
+		if ( $order_id ) {
+			$order = wc_get_order( $order_id );
+
+			if ( $order ) {
+				$email = $order->get_billing_email();
+			}
 		}
 
-		$order = wc_get_order( $order_id );
-
-		if ( ! $order ) {
-			return null;
+		// Fallback to buyer email if no order email found.
+		if ( empty( $email ) ) {
+			$buyer = $document->getBuyer();
+			if ( $buyer ) {
+				$email = $buyer->getEmail();
+			}
 		}
 
-		$email = $order->get_billing_email();
+		if ( empty( $email ) ) {
+			return null;
+		}
 
 		/**
 		 * Filter the recipient email address for document emails.
 		 *
-		 * @param string   $email    Recipient email.
-		 * @param Document $document The document.
-		 * @param \WC_Order $order   The WooCommerce order.
+		 * @param string        $email    Recipient email.
+		 * @param Document      $document The document.
+		 * @param \WC_Order|null $order   The WooCommerce order or null for manual documents.
 		 */
 		return apply_filters( 'ihumbak_email_recipient', $email, $document, $order );
 	}
@@ -203,10 +215,11 @@ class EmailService {
 		$emails = WC()->mailer()->get_emails();
 
 		$email_class = match ( $document->getDocumentType() ) {
-			'invoice'     => 'IHumbak_Invoice_Email',
-			'receipt'     => 'IHumbak_Receipt_Email',
-			'credit_note' => 'IHumbak_Credit_Note_Email',
-			default       => null,
+			'invoice'        => 'IHumbak_Invoice_Email',
+			'receipt'        => 'IHumbak_Receipt_Email',
+			'credit_note'    => 'IHumbak_Credit_Note_Email',
+			'receipt_return' => 'IHumbak_Receipt_Return_Email',
+			default          => null,
 		};
 
 		if ( ! $email_class || ! isset( $emails[ $email_class ] ) ) {

--- a/tests/Unit/Modules/Email/EmailServiceTest.php
+++ b/tests/Unit/Modules/Email/EmailServiceTest.php
@@ -14,6 +14,7 @@ use IHumbak\Invoices\Models\Invoice;
 use IHumbak\Invoices\Models\Receipt;
 use IHumbak\Invoices\Models\CreditNote;
 use IHumbak\Invoices\Models\Document;
+use IHumbak\Invoices\Models\Buyer;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -148,12 +149,49 @@ class EmailServiceTest extends TestCase {
 	}
 
 	/**
-	 * Test getRecipientEmail returns null when document has no order.
+	 * Test getRecipientEmail returns null when document has no order and no buyer email.
 	 */
-	public function test_get_recipient_email_returns_null_without_order(): void {
+	public function test_get_recipient_email_returns_null_without_order_and_buyer_email(): void {
 		$service  = $this->createEmailServiceWithMocks();
 		$document = new Invoice();
 		$document->setId( 1 );
+
+		$email = $service->getRecipientEmail( $document );
+
+		$this->assertNull( $email );
+	}
+
+	/**
+	 * Test getRecipientEmail returns buyer email when document has no order but has buyer with email.
+	 */
+	public function test_get_recipient_email_returns_buyer_email_for_manual_document(): void {
+		$service  = $this->createEmailServiceWithMocks();
+		$document = new Invoice();
+		$document->setId( 1 );
+
+		$buyer = new Buyer(
+			name: 'Test Customer',
+			email: 'customer@example.com'
+		);
+		$document->setBuyer( $buyer );
+
+		$email = $service->getRecipientEmail( $document );
+
+		$this->assertSame( 'customer@example.com', $email );
+	}
+
+	/**
+	 * Test getRecipientEmail returns null when document has buyer without email.
+	 */
+	public function test_get_recipient_email_returns_null_when_buyer_has_no_email(): void {
+		$service  = $this->createEmailServiceWithMocks();
+		$document = new Invoice();
+		$document->setId( 1 );
+
+		$buyer = new Buyer(
+			name: 'Test Customer'
+		);
+		$document->setBuyer( $buyer );
 
 		$email = $service->getRecipientEmail( $document );
 


### PR DESCRIPTION
## Summary
- Fix receipt return email sending which was failing due to missing case in `getEmailInstance()` match statement
- Enable Send Email action for manually created documents that have buyer email filled in
- Add fallback to buyer email in `getRecipientEmail()` when no WooCommerce order is linked

Fixes #20

## Test plan
- [ ] Create a receipt return document linked to an order and verify email can be sent
- [ ] Create a manual invoice with buyer email and verify Send Email action appears
- [ ] Create a manual document without buyer email and verify Send Email action does NOT appear
- [ ] Verify existing behavior for order-linked documents is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)