### PR TITLE
fix(admin): show Send Email button on edit page for manual documents

### DIFF
--- a/src/Models/Document.php
+++ b/src/Models/Document.php
@@ -406,6 +406,24 @@ abstract class Document {
 	}
 
 	/**
+	 * Check if document can be sent via email.
+	 *
+	 * Returns true if document has a linked WooCommerce order
+	 * or has a buyer with a non-empty email address.
+	 *
+	 * @return bool
+	 */
+	public function canSendEmail(): bool {
+		if ( $this->getOrderId() ) {
+			return true;
+		}
+
+		$buyer = $this->getBuyer();
+
+		return $buyer && ! empty( $buyer->getEmail() );
+	}
+
+	/**
 	 * Get seller.
 	 *
 	 * @return Seller|null

--- a/src/Modules/Admin/DocumentListTable.php
+++ b/src/Modules/Admin/DocumentListTable.php
@@ -224,9 +224,7 @@ class DocumentListTable extends \WP_List_Table {
 			);
 
 			// Add send email action for issued documents with email recipient available.
-			// Show when document has linked order OR buyer email (for manual documents).
-			$has_buyer_email = $item->getBuyer() && $item->getBuyer()->getEmail();
-			if ( ( $item->getOrderId() || $has_buyer_email ) && ! $item->wasSent() ) {
+			if ( $item->canSendEmail() && ! $item->wasSent() ) {
 				$email_url = add_query_arg(
 					array(
 						'page'   => 'ihumbak-invoices',

--- a/templates/admin/credit-note-edit.php
+++ b/templates/admin/credit-note-edit.php
@@ -398,7 +398,11 @@ $page_title = $is_new
 								<?php esc_html_e( 'Regenerate PDF', 'ihumbak-invoices' ); ?>
 							</a>
 						</p>
-						<?php if ( $document->getOrderId() ) : ?>
+						<?php
+						// Show Send Email when document has linked order OR buyer email (for manual documents).
+						$has_buyer_email = $document->getBuyer() && $document->getBuyer()->getEmail();
+						if ( $document->getOrderId() || $has_buyer_email ) :
+							?>
 							<?php
 							$email_url = add_query_arg(
 								array(

--- a/templates/admin/credit-note-edit.php
+++ b/templates/admin/credit-note-edit.php
@@ -398,11 +398,7 @@ $page_title = $is_new
 								<?php esc_html_e( 'Regenerate PDF', 'ihumbak-invoices' ); ?>
 							</a>
 						</p>
-						<?php
-						// Show Send Email when document has linked order OR buyer email (for manual documents).
-						$has_buyer_email = $document->getBuyer() && $document->getBuyer()->getEmail();
-						if ( $document->getOrderId() || $has_buyer_email ) :
-							?>
+						<?php if ( $document->canSendEmail() ) : ?>
 							<?php
 							$email_url = add_query_arg(
 								array(

--- a/templates/admin/invoice-edit.php
+++ b/templates/admin/invoice-edit.php
@@ -268,11 +268,7 @@ $page_title = $is_new
                                 <?php esc_html_e( 'Regenerate PDF', 'ihumbak-invoices' ); ?>
                             </a>
                         </p>
-                        <?php
-                        // Show Send Email when document has linked order OR buyer email (for manual documents).
-                        $has_buyer_email = $document->getBuyer() && $document->getBuyer()->getEmail();
-                        if ( $document->getOrderId() || $has_buyer_email ) :
-                            ?>
+                        <?php if ( $document->canSendEmail() ) : ?>
                             <?php
                             $email_url = add_query_arg(
                                 array(

--- a/templates/admin/invoice-edit.php
+++ b/templates/admin/invoice-edit.php
@@ -268,7 +268,11 @@ $page_title = $is_new
                                 <?php esc_html_e( 'Regenerate PDF', 'ihumbak-invoices' ); ?>
                             </a>
                         </p>
-                        <?php if ( $document->getOrderId() ) : ?>
+                        <?php
+                        // Show Send Email when document has linked order OR buyer email (for manual documents).
+                        $has_buyer_email = $document->getBuyer() && $document->getBuyer()->getEmail();
+                        if ( $document->getOrderId() || $has_buyer_email ) :
+                            ?>
                             <?php
                             $email_url = add_query_arg(
                                 array(

--- a/templates/admin/receipt-edit.php
+++ b/templates/admin/receipt-edit.php
@@ -256,11 +256,7 @@ $page_title = $is_new
                                 <?php esc_html_e( 'Regenerate PDF', 'ihumbak-invoices' ); ?>
                             </a>
                         </p>
-                        <?php
-                        // Show Send Email when document has linked order OR buyer email (for manual documents).
-                        $has_buyer_email = $document->getBuyer() && $document->getBuyer()->getEmail();
-                        if ( $document->getOrderId() || $has_buyer_email ) :
-                            ?>
+                        <?php if ( $document->canSendEmail() ) : ?>
                             <?php
                             $email_url = add_query_arg(
                                 array(

--- a/templates/admin/receipt-edit.php
+++ b/templates/admin/receipt-edit.php
@@ -256,7 +256,11 @@ $page_title = $is_new
                                 <?php esc_html_e( 'Regenerate PDF', 'ihumbak-invoices' ); ?>
                             </a>
                         </p>
-                        <?php if ( $document->getOrderId() ) : ?>
+                        <?php
+                        // Show Send Email when document has linked order OR buyer email (for manual documents).
+                        $has_buyer_email = $document->getBuyer() && $document->getBuyer()->getEmail();
+                        if ( $document->getOrderId() || $has_buyer_email ) :
+                            ?>
                             <?php
                             $email_url = add_query_arg(
                                 array(

--- a/templates/admin/receipt-return-edit.php
+++ b/templates/admin/receipt-return-edit.php
@@ -405,7 +405,11 @@ $page_title = $is_new
 								<?php esc_html_e( 'Regenerate PDF', 'ihumbak-invoices' ); ?>
 							</a>
 						</p>
-						<?php if ( $document->getOrderId() ) : ?>
+						<?php
+						// Show Send Email when document has linked order OR buyer email (for manual documents).
+						$has_buyer_email = $document->getBuyer() && $document->getBuyer()->getEmail();
+						if ( $document->getOrderId() || $has_buyer_email ) :
+							?>
 							<?php
 							$email_url = add_query_arg(
 								array(

--- a/templates/admin/receipt-return-edit.php
+++ b/templates/admin/receipt-return-edit.php
@@ -405,11 +405,7 @@ $page_title = $is_new
 								<?php esc_html_e( 'Regenerate PDF', 'ihumbak-invoices' ); ?>
 							</a>
 						</p>
-						<?php
-						// Show Send Email when document has linked order OR buyer email (for manual documents).
-						$has_buyer_email = $document->getBuyer() && $document->getBuyer()->getEmail();
-						if ( $document->getOrderId() || $has_buyer_email ) :
-							?>
+						<?php if ( $document->canSendEmail() ) : ?>
 							<?php
 							$email_url = add_query_arg(
 								array(

--- a/tests/Unit/Models/InvoiceTest.php
+++ b/tests/Unit/Models/InvoiceTest.php
@@ -683,4 +683,68 @@ class InvoiceTest extends TestCase {
 		$this->assertNull( $invoice->getPaymentDate() );
 		$this->assertFalse( $invoice->isPaid() );
 	}
+
+	/**
+	 * Test canSendEmail returns true when document has order ID.
+	 */
+	public function test_can_send_email_returns_true_with_order_id(): void {
+		$invoice = new Invoice();
+		$invoice->setOrderId( 100 );
+
+		$this->assertTrue( $invoice->canSendEmail() );
+	}
+
+	/**
+	 * Test canSendEmail returns true when document has buyer with email.
+	 */
+	public function test_can_send_email_returns_true_with_buyer_email(): void {
+		$invoice = new Invoice();
+		$buyer   = new Buyer( name: 'Test Buyer', email: 'test@example.com' );
+		$invoice->setBuyer( $buyer );
+
+		$this->assertTrue( $invoice->canSendEmail() );
+	}
+
+	/**
+	 * Test canSendEmail returns false when document has no order and no buyer.
+	 */
+	public function test_can_send_email_returns_false_without_order_and_buyer(): void {
+		$invoice = new Invoice();
+
+		$this->assertFalse( $invoice->canSendEmail() );
+	}
+
+	/**
+	 * Test canSendEmail returns false when document has buyer without email.
+	 */
+	public function test_can_send_email_returns_false_with_buyer_without_email(): void {
+		$invoice = new Invoice();
+		$buyer   = new Buyer( name: 'Test Buyer' );
+		$invoice->setBuyer( $buyer );
+
+		$this->assertFalse( $invoice->canSendEmail() );
+	}
+
+	/**
+	 * Test canSendEmail returns false when document has buyer with empty email.
+	 */
+	public function test_can_send_email_returns_false_with_buyer_empty_email(): void {
+		$invoice = new Invoice();
+		$buyer   = new Buyer( name: 'Test Buyer', email: '' );
+		$invoice->setBuyer( $buyer );
+
+		$this->assertFalse( $invoice->canSendEmail() );
+	}
+
+	/**
+	 * Test canSendEmail returns true when document has both order ID and buyer email.
+	 */
+	public function test_can_send_email_returns_true_with_both_order_and_buyer_email(): void {
+		$invoice = new Invoice();
+		$invoice->setOrderId( 100 );
+		$buyer = new Buyer( name: 'Test Buyer', email: 'test@example.com' );
+		$invoice->setBuyer( $buyer );
+
+		$this->assertTrue( $invoice->canSendEmail() );
+	}
 }


### PR DESCRIPTION
## Summary
- Fixed Send Email button not appearing on document edit pages for manual documents (without order_id)
- Updated condition in all 4 edit templates to check for buyer email in addition to order_id
- Affected templates: invoice-edit.php, receipt-edit.php, credit-note-edit.php, receipt-return-edit.php

## Test plan
- [ ] Open edit page for a manual document with buyer email (e.g., document ID 39)
- [ ] Verify "Send Email" button appears in the Actions section
- [ ] Click "Send Email" and verify email is sent successfully
- [ ] Test on all document types: invoice, receipt, credit note, receipt return

Fixes #20

🤖 Generated with [Claude Code](https://claude.ai/code)