### PR TITLE
refactor(automation): remove automatic document generation feature

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -42,10 +42,8 @@ Access in admin: **WooCommerce > Invoices > Settings**
         'logo_id' => 0,
         'footer_text' => '',
     ],
-    'automation' => [
-        'auto_generate_invoice' => false,
-        'auto_generate_receipt' => false,
-        'trigger_status' => 'completed',
+    'display' => [
+        'show_order_column' => true,
         'nip_meta_key' => '_billing_nip',
     ],
 ]
@@ -107,13 +105,11 @@ Email: invoices@example.com
 2. `wp-content/themes/{parent-theme}/ihumbak-invoices/{template}/`
 3. `{plugin}/templates/pdf/{template}/`
 
-### 4. Automation Tab
+### 4. Display Tab
 
 | Option | Type | Description |
 |--------|------|-------------|
-| auto_generate_invoice | boolean | Auto-generate invoice on order status change |
-| auto_generate_receipt | boolean | Auto-generate receipt on order status change |
-| trigger_status | string | Order status that triggers auto-generation |
+| show_order_column | boolean | Show documents column in WooCommerce orders list |
 | nip_meta_key | string | Order meta key for buyer NIP/VAT number |
 
 ---

--- a/src/Core/Activator.php
+++ b/src/Core/Activator.php
@@ -101,8 +101,46 @@ class Activator {
 			add_option( 'ihumbak_invoices_settings', $defaults );
 		}
 
+		// Run migrations for existing installations.
+		self::migrate_settings();
+
 		// Store plugin version.
 		update_option( 'ihumbak_invoices_version', IHUMBAK_INVOICES_VERSION );
+	}
+
+	/**
+	 * Migrate settings from older versions.
+	 *
+	 * @return void
+	 */
+	private static function migrate_settings(): void {
+		$settings = get_option( 'ihumbak_invoices_settings' );
+
+		if ( ! is_array( $settings ) ) {
+			return;
+		}
+
+		$updated = false;
+
+		// Migrate nip_meta_key from automation to display section.
+		if ( isset( $settings['automation']['nip_meta_key'] ) ) {
+			// Only migrate if display.nip_meta_key is not set or is default value.
+			if ( ! isset( $settings['display']['nip_meta_key'] )
+				|| '_billing_nip' === $settings['display']['nip_meta_key'] ) {
+				$settings['display']['nip_meta_key'] = $settings['automation']['nip_meta_key'];
+				$updated                             = true;
+			}
+		}
+
+		// Clean up deprecated automation section.
+		if ( isset( $settings['automation'] ) ) {
+			unset( $settings['automation'] );
+			$updated = true;
+		}
+
+		if ( $updated ) {
+			update_option( 'ihumbak_invoices_settings', $settings );
+		}
 	}
 
 	/**

--- a/src/Core/Activator.php
+++ b/src/Core/Activator.php
@@ -77,25 +77,24 @@ class Activator {
 
 		if ( false === $existing ) {
 			$defaults = array(
-				'seller'     => array(
+				'seller'    => array(
 					'name'    => get_bloginfo( 'name' ),
 					'details' => '',
 				),
-				'numbering'  => array(
+				'numbering' => array(
 					'invoice_pattern'    => 'FV/{YYYY}/{MM}/{NNNN}',
 					'receipt_pattern'    => 'PAR/{YYYY}/{MM}/{NNNN}',
 					'correction_pattern' => 'FK/{YYYY}/{MM}/{NNNN}',
 					'reset_monthly'      => true,
 				),
-				'pdf'        => array(
+				'pdf'       => array(
 					'template'    => 'default',
 					'logo_id'     => 0,
 					'footer_text' => '',
 				),
-				'automation' => array(
-					'auto_generate_invoice' => false,
-					'auto_generate_receipt' => false,
-					'trigger_status'        => 'completed',
+				'display'   => array(
+					'show_order_column' => true,
+					'nip_meta_key'      => '_billing_nip',
 				),
 			);
 

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -270,9 +270,6 @@ final class Plugin {
 		// Frontend hooks.
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend_assets' ) );
 
-		// WooCommerce hooks.
-		add_action( 'woocommerce_order_status_changed', array( $this, 'handle_order_status_change' ), 10, 4 );
-
 		// Register WooCommerce email classes.
 		add_filter( 'woocommerce_email_classes', array( $this, 'register_email_classes' ) );
 
@@ -739,35 +736,6 @@ final class Plugin {
 	}
 
 	/**
-	 * Handle order status change.
-	 *
-	 * @param int       $order_id   Order ID.
-	 * @param string    $old_status Old status.
-	 * @param string    $new_status New status.
-	 * @param \WC_Order $order      Order object.
-	 * @return void
-	 */
-	public function handle_order_status_change( int $order_id, string $old_status, string $new_status, \WC_Order $order ): void {
-		$settings = $this->get_settings();
-
-		if ( empty( $settings['automation']['auto_generate_invoice'] ) ) {
-			return;
-		}
-
-		$trigger_status = $settings['automation']['trigger_status'] ?? 'completed';
-
-		if ( $new_status === $trigger_status ) {
-			/**
-			 * Fires when an invoice should be auto-generated.
-			 *
-			 * @param int       $order_id Order ID.
-			 * @param \WC_Order $order    Order object.
-			 */
-			do_action( 'ihumbak_auto_generate_invoice', $order_id, $order );
-		}
-	}
-
-	/**
 	 * Get plugin settings.
 	 *
 	 * @return array<string, mixed>
@@ -801,14 +769,9 @@ final class Plugin {
 				'logo_id'     => 0,
 				'footer_text' => '',
 			),
-			'automation'  => array(
-				'auto_generate_invoice' => false,
-				'auto_generate_receipt' => false,
-				'trigger_status'        => 'completed',
-				'nip_meta_key'          => '_billing_nip',
-			),
 			'display'     => array(
 				'show_order_column' => true,
+				'nip_meta_key'      => '_billing_nip',
 			),
 			'permissions' => array(
 				'minimum_role' => PermissionService::DEFAULT_ROLE,
@@ -862,20 +825,11 @@ final class Plugin {
 			);
 		}
 
-		// Sanitize automation settings.
-		if ( isset( $input['automation'] ) && is_array( $input['automation'] ) ) {
-			$sanitized['automation'] = array(
-				'auto_generate_invoice' => ! empty( $input['automation']['auto_generate_invoice'] ),
-				'auto_generate_receipt' => ! empty( $input['automation']['auto_generate_receipt'] ),
-				'trigger_status'        => sanitize_text_field( $input['automation']['trigger_status'] ?? 'completed' ),
-				'nip_meta_key'          => sanitize_text_field( $input['automation']['nip_meta_key'] ?? '_billing_nip' ),
-			);
-		}
-
 		// Sanitize display settings.
 		if ( isset( $input['display'] ) && is_array( $input['display'] ) ) {
 			$sanitized['display'] = array(
 				'show_order_column' => ! empty( $input['display']['show_order_column'] ),
+				'nip_meta_key'      => sanitize_text_field( $input['display']['nip_meta_key'] ?? '_billing_nip' ),
 			);
 		}
 

--- a/src/Modules/Admin/AjaxController.php
+++ b/src/Modules/Admin/AjaxController.php
@@ -264,7 +264,7 @@ class AjaxController {
 
 		// Get NIP meta key from settings.
 		$settings     = Plugin::get_instance()->get_settings();
-		$nip_meta_key = $settings['automation']['nip_meta_key'] ?? '_billing_nip';
+		$nip_meta_key = $settings['display']['nip_meta_key'] ?? '_billing_nip';
 
 		$data = $this->order_extractor->extractAll( $order, $nip_meta_key );
 

--- a/templates/admin/settings.php
+++ b/templates/admin/settings.php
@@ -27,10 +27,6 @@ $active_tab = isset( $_GET['tab'] ) ? sanitize_text_field( wp_unslash( $_GET['ta
            class="nav-tab <?php echo 'pdf' === $active_tab ? 'nav-tab-active' : ''; ?>">
             <?php esc_html_e( 'PDF', 'ihumbak-invoices' ); ?>
         </a>
-        <a href="<?php echo esc_url( admin_url( 'admin.php?page=ihumbak-invoices-settings&tab=automation' ) ); ?>"
-           class="nav-tab <?php echo 'automation' === $active_tab ? 'nav-tab-active' : ''; ?>">
-            <?php esc_html_e( 'Automation', 'ihumbak-invoices' ); ?>
-        </a>
         <a href="<?php echo esc_url( admin_url( 'admin.php?page=ihumbak-invoices-settings&tab=display' ) ); ?>"
            class="nav-tab <?php echo 'display' === $active_tab ? 'nav-tab-active' : ''; ?>">
             <?php esc_html_e( 'Display', 'ihumbak-invoices' ); ?>
@@ -207,68 +203,6 @@ $active_tab = isset( $_GET['tab'] ) ? sanitize_text_field( wp_unslash( $_GET['ta
                 </tr>
             </table>
 
-        <?php elseif ( 'automation' === $active_tab ) : ?>
-            <table class="form-table">
-                <tr>
-                    <th scope="row"><?php esc_html_e( 'Auto-generate Invoice', 'ihumbak-invoices' ); ?></th>
-                    <td>
-                        <label>
-                            <input type="checkbox"
-                                   name="ihumbak_invoices_settings[automation][auto_generate_invoice]"
-                                   value="1"
-                                   <?php checked( ! empty( $settings['automation']['auto_generate_invoice'] ) ); ?>>
-                            <?php esc_html_e( 'Automatically generate invoice when order status changes', 'ihumbak-invoices' ); ?>
-                        </label>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><?php esc_html_e( 'Auto-generate Receipt', 'ihumbak-invoices' ); ?></th>
-                    <td>
-                        <label>
-                            <input type="checkbox"
-                                   name="ihumbak_invoices_settings[automation][auto_generate_receipt]"
-                                   value="1"
-                                   <?php checked( ! empty( $settings['automation']['auto_generate_receipt'] ) ); ?>>
-                            <?php esc_html_e( 'Automatically generate receipt for orders without NIP', 'ihumbak-invoices' ); ?>
-                        </label>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row">
-                        <label for="trigger_status"><?php esc_html_e( 'Trigger Status', 'ihumbak-invoices' ); ?></label>
-                    </th>
-                    <td>
-                        <select id="trigger_status" name="ihumbak_invoices_settings[automation][trigger_status]">
-                            <option value="processing" <?php selected( ( $settings['automation']['trigger_status'] ?? 'completed' ), 'processing' ); ?>>
-                                <?php esc_html_e( 'Processing', 'ihumbak-invoices' ); ?>
-                            </option>
-                            <option value="completed" <?php selected( ( $settings['automation']['trigger_status'] ?? 'completed' ), 'completed' ); ?>>
-                                <?php esc_html_e( 'Completed', 'ihumbak-invoices' ); ?>
-                            </option>
-                        </select>
-                        <p class="description">
-                            <?php esc_html_e( 'Order status that triggers automatic document generation', 'ihumbak-invoices' ); ?>
-                        </p>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row">
-                        <label for="nip_meta_key"><?php esc_html_e( 'NIP Meta Key', 'ihumbak-invoices' ); ?></label>
-                    </th>
-                    <td>
-                        <input type="text"
-                               id="nip_meta_key"
-                               name="ihumbak_invoices_settings[automation][nip_meta_key]"
-                               value="<?php echo esc_attr( $settings['automation']['nip_meta_key'] ?? '_billing_nip' ); ?>"
-                               class="regular-text"
-                               placeholder="_billing_nip">
-                        <p class="description">
-                            <?php esc_html_e( 'Order meta key where customer NIP/Tax ID is stored. Common values: _billing_nip, billing_nip, _vat_number', 'ihumbak-invoices' ); ?>
-                        </p>
-                    </td>
-                </tr>
-            </table>
-
         <?php elseif ( 'display' === $active_tab ) : ?>
             <table class="form-table">
                 <tr>
@@ -283,6 +217,22 @@ $active_tab = isset( $_GET['tab'] ) ? sanitize_text_field( wp_unslash( $_GET['ta
                         </label>
                         <p class="description">
                             <?php esc_html_e( 'Displays invoice, receipt and credit note numbers directly in the orders list.', 'ihumbak-invoices' ); ?>
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row">
+                        <label for="nip_meta_key"><?php esc_html_e( 'NIP Meta Key', 'ihumbak-invoices' ); ?></label>
+                    </th>
+                    <td>
+                        <input type="text"
+                               id="nip_meta_key"
+                               name="ihumbak_invoices_settings[display][nip_meta_key]"
+                               value="<?php echo esc_attr( $settings['display']['nip_meta_key'] ?? '_billing_nip' ); ?>"
+                               class="regular-text"
+                               placeholder="_billing_nip">
+                        <p class="description">
+                            <?php esc_html_e( 'Order meta key where customer NIP/Tax ID is stored. Common values: _billing_nip, billing_nip, _vat_number', 'ihumbak-invoices' ); ?>
                         </p>
                     </td>
                 </tr>

--- a/tests/Unit/Core/ActivatorTest.php
+++ b/tests/Unit/Core/ActivatorTest.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * Activator unit tests.
+ *
+ * @package IHumbak\Invoices\Tests\Unit\Core
+ */
+
+declare(strict_types=1);
+
+namespace IHumbak\Invoices\Tests\Unit\Core;
+
+use IHumbak\Invoices\Core\Activator;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * Test case for Activator class.
+ */
+class ActivatorTest extends TestCase {
+
+	/**
+	 * Set up test fixtures.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		// Clear mock options before each test.
+		global $mock_wp_options;
+		$mock_wp_options = array();
+	}
+
+	/**
+	 * Test migrate_settings migrates nip_meta_key from automation to display.
+	 *
+	 * @return void
+	 */
+	public function test_migrate_settings_moves_nip_meta_key_from_automation_to_display(): void {
+		// Setup: old settings with automation.nip_meta_key.
+		update_option(
+			'ihumbak_invoices_settings',
+			array(
+				'seller'     => array(
+					'name' => 'Test Company',
+				),
+				'automation' => array(
+					'auto_generate_invoice' => true,
+					'nip_meta_key'          => '_custom_vat_number',
+				),
+				'display'    => array(
+					'show_order_column' => true,
+				),
+			)
+		);
+
+		// Act: invoke private migrate_settings method via reflection.
+		$this->invoke_migrate_settings();
+
+		// Assert: nip_meta_key is migrated to display section.
+		$settings = get_option( 'ihumbak_invoices_settings' );
+
+		$this->assertEquals( '_custom_vat_number', $settings['display']['nip_meta_key'] );
+		$this->assertArrayNotHasKey( 'automation', $settings );
+	}
+
+	/**
+	 * Test migrate_settings preserves existing display.nip_meta_key if not default.
+	 *
+	 * @return void
+	 */
+	public function test_migrate_settings_preserves_non_default_display_nip_meta_key(): void {
+		// Setup: settings with both automation and display nip_meta_key (non-default).
+		update_option(
+			'ihumbak_invoices_settings',
+			array(
+				'automation' => array(
+					'nip_meta_key' => '_old_automation_key',
+				),
+				'display'    => array(
+					'show_order_column' => true,
+					'nip_meta_key'      => '_already_configured_key',
+				),
+			)
+		);
+
+		// Act: invoke private migrate_settings method.
+		$this->invoke_migrate_settings();
+
+		// Assert: existing non-default display.nip_meta_key is preserved.
+		$settings = get_option( 'ihumbak_invoices_settings' );
+
+		$this->assertEquals( '_already_configured_key', $settings['display']['nip_meta_key'] );
+		$this->assertArrayNotHasKey( 'automation', $settings );
+	}
+
+	/**
+	 * Test migrate_settings migrates when display.nip_meta_key is default value.
+	 *
+	 * @return void
+	 */
+	public function test_migrate_settings_overwrites_default_display_nip_meta_key(): void {
+		// Setup: settings with automation.nip_meta_key and default display.nip_meta_key.
+		update_option(
+			'ihumbak_invoices_settings',
+			array(
+				'automation' => array(
+					'nip_meta_key' => '_custom_from_automation',
+				),
+				'display'    => array(
+					'show_order_column' => true,
+					'nip_meta_key'      => '_billing_nip', // Default value.
+				),
+			)
+		);
+
+		// Act: invoke private migrate_settings method.
+		$this->invoke_migrate_settings();
+
+		// Assert: default value is overwritten with automation value.
+		$settings = get_option( 'ihumbak_invoices_settings' );
+
+		$this->assertEquals( '_custom_from_automation', $settings['display']['nip_meta_key'] );
+	}
+
+	/**
+	 * Test migrate_settings removes automation section completely.
+	 *
+	 * @return void
+	 */
+	public function test_migrate_settings_removes_automation_section(): void {
+		// Setup: settings with automation section (but no nip_meta_key).
+		update_option(
+			'ihumbak_invoices_settings',
+			array(
+				'seller'     => array(
+					'name' => 'Test Company',
+				),
+				'automation' => array(
+					'auto_generate_invoice' => true,
+					'trigger_status'        => 'completed',
+				),
+			)
+		);
+
+		// Act: invoke private migrate_settings method.
+		$this->invoke_migrate_settings();
+
+		// Assert: automation section is removed.
+		$settings = get_option( 'ihumbak_invoices_settings' );
+
+		$this->assertArrayNotHasKey( 'automation', $settings );
+		$this->assertEquals( 'Test Company', $settings['seller']['name'] );
+	}
+
+	/**
+	 * Test migrate_settings does nothing when no settings exist.
+	 *
+	 * @return void
+	 */
+	public function test_migrate_settings_handles_no_settings(): void {
+		// Setup: no settings.
+		delete_option( 'ihumbak_invoices_settings' );
+
+		// Act: invoke private migrate_settings method - should not throw.
+		$this->invoke_migrate_settings();
+
+		// Assert: no settings created.
+		$this->assertFalse( get_option( 'ihumbak_invoices_settings' ) );
+	}
+
+	/**
+	 * Test migrate_settings does nothing when settings is not array.
+	 *
+	 * @return void
+	 */
+	public function test_migrate_settings_handles_non_array_settings(): void {
+		// Setup: invalid settings value.
+		update_option( 'ihumbak_invoices_settings', 'invalid' );
+
+		// Act: invoke private migrate_settings method - should not throw.
+		$this->invoke_migrate_settings();
+
+		// Assert: settings unchanged.
+		$this->assertEquals( 'invalid', get_option( 'ihumbak_invoices_settings' ) );
+	}
+
+	/**
+	 * Invoke the private migrate_settings method using reflection.
+	 *
+	 * @return void
+	 */
+	private function invoke_migrate_settings(): void {
+		$reflection = new ReflectionClass( Activator::class );
+		$method     = $reflection->getMethod( 'migrate_settings' );
+		$method->setAccessible( true );
+		$method->invoke( null );
+	}
+}

--- a/tests/Unit/Core/PluginTest.php
+++ b/tests/Unit/Core/PluginTest.php
@@ -178,32 +178,29 @@ class PluginTest extends TestCase {
 	}
 
 	/**
-	 * Test sanitize_settings preserves all five tabs independently.
+	 * Test sanitize_settings preserves all tabs independently.
 	 *
 	 * @return void
 	 */
-	public function test_sanitize_settings_preserves_all_five_tabs(): void {
-		// Setup: all five tabs have data.
+	public function test_sanitize_settings_preserves_all_tabs(): void {
+		// Setup: all tabs have data.
 		update_option(
 			'ihumbak_invoices_settings',
 			array(
-				'seller'     => array(
+				'seller'    => array(
 					'name'    => 'Seller Name',
 					'details' => 'Seller Details',
 				),
-				'numbering'  => array(
+				'numbering' => array(
 					'invoice_pattern' => 'FV/{YYYY}/{NNNN}',
 					'reset_monthly'   => true,
 				),
-				'pdf'        => array(
+				'pdf'       => array(
 					'template' => 'default',
 				),
-				'automation' => array(
-					'auto_generate_invoice' => true,
-					'trigger_status'        => 'completed',
-				),
-				'display'    => array(
+				'display'   => array(
 					'show_order_column' => true,
+					'nip_meta_key'      => '_billing_nip',
 				),
 			)
 		);
@@ -214,6 +211,7 @@ class PluginTest extends TestCase {
 		$input = array(
 			'display' => array(
 				'show_order_column' => false,
+				'nip_meta_key'      => '_vat_number',
 			),
 		);
 
@@ -221,11 +219,11 @@ class PluginTest extends TestCase {
 
 		// Assert: display is updated.
 		$this->assertFalse( $result['display']['show_order_column'] );
+		$this->assertEquals( '_vat_number', $result['display']['nip_meta_key'] );
 
 		// Assert: all other tabs are preserved.
 		$this->assertEquals( 'Seller Name', $result['seller']['name'] );
 		$this->assertEquals( 'FV/{YYYY}/{NNNN}', $result['numbering']['invoice_pattern'] );
 		$this->assertEquals( 'default', $result['pdf']['template'] );
-		$this->assertTrue( $result['automation']['auto_generate_invoice'] );
 	}
 }


### PR DESCRIPTION
## Summary

- Remove the entire "Automation" feature that auto-generated invoices/receipts on order status change
- Documents should now always be generated manually by the user
- Move `nip_meta_key` setting from Automation tab to Display tab

## Changes

| File | Change |
|------|--------|
| `templates/admin/settings.php` | Remove Automation tab and section |
| `src/Core/Plugin.php` | Remove hook, handler method, and default settings |
| `src/Core/Activator.php` | Remove automation defaults |
| `src/Modules/Admin/AjaxController.php` | Update nip_meta_key reference |
| `tests/Unit/Core/PluginTest.php` | Update tests |
| `docs/CONFIGURATION.md` | Update documentation |

## Test plan

- [ ] Verify "Automation" tab is no longer visible in plugin settings
- [ ] Verify no automatic document generation when order status changes
- [ ] Verify NIP Meta Key setting works correctly in Display tab
- [ ] Run `composer test` - all 457 tests pass
- [ ] Run `composer phpcs` - no errors
- [ ] Run `composer phpstan` - no errors

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)