### PR TITLE
feat(order-status): add automatic order status change on document issue

### DIFF
--- a/assets/js/document-edit.js
+++ b/assets/js/document-edit.js
@@ -48,6 +48,7 @@
             this.initFetchOrder();
             this.initCreditNote();
             this.initReceiptReturn();
+            this.initOrderStatusCheckbox();
 
             // Form validation before submit.
             $('#ihumbak-document-form').on('submit', function(e) {
@@ -415,6 +416,40 @@
                     self.fetchOrderData(orderId);
                 }
             });
+        },
+
+        /**
+         * Initialize order status checkbox visibility toggle.
+         *
+         * Shows/hides the order status change checkbox based on whether
+         * an order ID is entered in the form.
+         */
+        initOrderStatusCheckbox: function() {
+            var $orderIdInput = $('#order_id');
+            var $checkboxWrapper = $('#ihumbak-order-status-change-wrapper');
+
+            // Skip if no checkbox wrapper (feature disabled or not on invoice/receipt page).
+            if (!$checkboxWrapper.length) {
+                return;
+            }
+
+            /**
+             * Toggle checkbox visibility based on order ID.
+             */
+            function toggleCheckboxVisibility() {
+                var orderId = parseInt($orderIdInput.val(), 10);
+                if (orderId && orderId > 0) {
+                    $checkboxWrapper.show();
+                } else {
+                    $checkboxWrapper.hide();
+                }
+            }
+
+            // Bind to order_id input changes.
+            $orderIdInput.on('input change', toggleCheckboxVisibility);
+
+            // Set initial state.
+            toggleCheckboxVisibility();
         },
 
         /**

--- a/docs/HOOKS-API.md
+++ b/docs/HOOKS-API.md
@@ -30,6 +30,35 @@ do_action('ihumbak_document_reverted_to_draft', Document $document, int $user_id
 | $document | Document | The reverted document |
 | $user_id | int | User ID who performed the action |
 
+### Order Status Change
+
+#### `ihumbak_before_order_status_change`
+Fired before an order status is changed when issuing a document.
+
+```php
+do_action('ihumbak_before_order_status_change', int $order_id, string $new_status, Document $document);
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| $order_id | int | WooCommerce order ID |
+| $new_status | string | New status being set |
+| $document | Document | The issued document |
+
+#### `ihumbak_after_order_status_change`
+Fired after an order status is changed when issuing a document.
+
+```php
+do_action('ihumbak_after_order_status_change', int $order_id, string $new_status, string $old_status, Document $document);
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| $order_id | int | WooCommerce order ID |
+| $new_status | string | New status that was set |
+| $old_status | string | Previous order status |
+| $document | Document | The issued document |
+
 ### PDF Generation
 
 #### `ihumbak_before_pdf_render`
@@ -344,13 +373,85 @@ add_filter('ihumbak_is_user_super_admin', function($is_super_admin, $user_id) {
 }, 10, 2);
 ```
 
+### Order Status Change
+
+#### `ihumbak_order_status_change_enabled`
+Override whether automatic order status change should happen for a specific document.
+
+```php
+apply_filters('ihumbak_order_status_change_enabled', bool $enabled, int $order_id, Document $document);
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| $enabled | bool | Whether status change is enabled |
+| $order_id | int | WooCommerce order ID |
+| $document | Document | The document being issued |
+
+**Example:**
+```php
+// Disable status change for orders from specific customer
+add_filter('ihumbak_order_status_change_enabled', function($enabled, $order_id, $document) {
+    $order = wc_get_order($order_id);
+    if ($order && $order->get_customer_id() === 123) {
+        return false;
+    }
+    return $enabled;
+}, 10, 3);
+```
+
+#### `ihumbak_order_status_change_target`
+Override the target order status for a specific document.
+
+```php
+apply_filters('ihumbak_order_status_change_target', string $status, int $order_id, Document $document);
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| $status | string | Target order status |
+| $order_id | int | WooCommerce order ID |
+| $document | Document | The document being issued |
+
+**Example:**
+```php
+// Set different status for receipts
+add_filter('ihumbak_order_status_change_target', function($status, $order_id, $document) {
+    if ($document->getDocumentType() === 'receipt') {
+        return 'processing';
+    }
+    return $status;
+}, 10, 3);
+```
+
+#### `ihumbak_order_status_change_checkbox_default`
+Change the default checkbox state for order status change.
+
+```php
+apply_filters('ihumbak_order_status_change_checkbox_default', bool $checked, int|null $order_id);
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| $checked | bool | Default checked state |
+| $order_id | int\|null | WooCommerce order ID or null for new documents |
+
+**Example:**
+```php
+// Default to unchecked for all documents
+add_filter('ihumbak_order_status_change_checkbox_default', function($checked, $order_id) {
+    return false;
+}, 10, 2);
+```
+
 ---
 
 ## Related Files
 
 - `src/Modules/Invoice/NumberingService.php` - Numbering hooks
 - `src/Modules/Invoice/OrderDataExtractor.php` - Payment method hooks
-- `src/Modules/Admin/SuperAdminService.php` - Super-admin hooks
+- `src/Modules/Invoice/OrderStatusService.php` - Order status change hooks
+- `src/Modules/Invoice/SuperAdminService.php` - Super-admin hooks
 - `src/Modules/PDF/PdfGenerator.php` - PDF hooks
 - `src/Modules/Email/EmailService.php` - Email hooks
 - `src/Modules/Email/AbstractDocumentEmail.php` - Email template hooks

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -772,6 +772,10 @@ final class Plugin {
 			'display'     => array(
 				'show_order_column' => true,
 				'nip_meta_key'      => '_billing_nip',
+				'order_status'      => array(
+					'enabled' => false,
+					'target'  => 'completed',
+				),
 			),
 			'permissions' => array(
 				'minimum_role' => PermissionService::DEFAULT_ROLE,
@@ -827,10 +831,36 @@ final class Plugin {
 
 		// Sanitize display settings.
 		if ( isset( $input['display'] ) && is_array( $input['display'] ) ) {
+			// Preserve existing order_status settings if not being updated.
+			$existing_order_status = $sanitized['display']['order_status'] ?? array(
+				'enabled' => false,
+				'target'  => 'completed',
+			);
+
 			$sanitized['display'] = array(
 				'show_order_column' => ! empty( $input['display']['show_order_column'] ),
 				'nip_meta_key'      => sanitize_text_field( $input['display']['nip_meta_key'] ?? '_billing_nip' ),
+				'order_status'      => $existing_order_status,
 			);
+
+			// Sanitize order_status settings if provided.
+			if ( isset( $input['display']['order_status'] ) && is_array( $input['display']['order_status'] ) ) {
+				$order_status_input = $input['display']['order_status'];
+				$target_status      = sanitize_text_field( $order_status_input['target'] ?? 'completed' );
+
+				// Validate target against WooCommerce order statuses.
+				if ( function_exists( 'wc_get_order_statuses' ) ) {
+					$valid_statuses = array_keys( wc_get_order_statuses() );
+					if ( ! in_array( 'wc-' . $target_status, $valid_statuses, true ) && ! in_array( $target_status, $valid_statuses, true ) ) {
+						$target_status = 'completed';
+					}
+				}
+
+				$sanitized['display']['order_status'] = array(
+					'enabled' => ! empty( $order_status_input['enabled'] ),
+					'target'  => $target_status,
+				);
+			}
 		}
 
 		// Sanitize permissions settings.

--- a/src/Modules/Admin/DocumentController.php
+++ b/src/Modules/Admin/DocumentController.php
@@ -20,6 +20,7 @@ use IHumbak\Invoices\Models\DocumentItem;
 use IHumbak\Invoices\Models\Buyer;
 use IHumbak\Invoices\Models\Seller;
 use IHumbak\Invoices\Modules\Invoice\NumberingService;
+use IHumbak\Invoices\Modules\Invoice\OrderStatusService;
 use IHumbak\Invoices\Modules\Invoice\RefundDataExtractor;
 use IHumbak\Invoices\Modules\Invoice\SuperAdminService;
 use IHumbak\Invoices\Core\Plugin;
@@ -533,6 +534,14 @@ class DocumentController {
 
 			if ( 'issue' === $save_action ) {
 				do_action( 'ihumbak_document_issued', $document );
+
+				// Handle order status change if requested.
+				// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified above.
+				$change_status = ! empty( $_POST['change_order_status'] );
+				if ( $change_status ) {
+					$order_status_service = new OrderStatusService();
+					$order_status_service->maybeChangeOrderStatus( $document, $change_status );
+				}
 			}
 
 			// Redirect back with success message.

--- a/src/Modules/Invoice/OrderStatusService.php
+++ b/src/Modules/Invoice/OrderStatusService.php
@@ -1,0 +1,237 @@
+<?php
+/**
+ * Order Status Service.
+ *
+ * @package IHumbak\Invoices\Modules\Invoice
+ */
+
+declare(strict_types=1);
+
+namespace IHumbak\Invoices\Modules\Invoice;
+
+use IHumbak\Invoices\Core\Plugin;
+use IHumbak\Invoices\Models\Document;
+
+/**
+ * Service for handling automatic order status changes when documents are issued.
+ */
+class OrderStatusService {
+
+	/**
+	 * Document types that support automatic order status change.
+	 *
+	 * @var string[]
+	 */
+	private const SUPPORTED_DOCUMENT_TYPES = array(
+		'invoice',
+		'receipt',
+	);
+
+	/**
+	 * Check if automatic order status change feature is enabled.
+	 *
+	 * @return bool True if enabled.
+	 */
+	public function isEnabled(): bool {
+		$settings = Plugin::get_instance()->get_settings();
+
+		return ! empty( $settings['display']['order_status']['enabled'] );
+	}
+
+	/**
+	 * Get the configured target status.
+	 *
+	 * @return string Target status (without 'wc-' prefix).
+	 */
+	public function getTargetStatus(): string {
+		$settings = Plugin::get_instance()->get_settings();
+
+		return $settings['display']['order_status']['target'] ?? 'completed';
+	}
+
+	/**
+	 * Get available WooCommerce order statuses for settings dropdown.
+	 *
+	 * @return array<string, string> Array of status slug => label.
+	 */
+	public function getOrderStatuses(): array {
+		if ( ! function_exists( 'wc_get_order_statuses' ) ) {
+			return array();
+		}
+
+		$statuses  = wc_get_order_statuses();
+		$formatted = array();
+
+		foreach ( $statuses as $status => $label ) {
+			// Remove 'wc-' prefix for storage.
+			$slug               = str_replace( 'wc-', '', $status );
+			$formatted[ $slug ] = $label;
+		}
+
+		return $formatted;
+	}
+
+	/**
+	 * Check if order status should be changed for this document.
+	 *
+	 * @param Document $document The document being issued.
+	 * @return bool True if status should be changed.
+	 */
+	public function shouldChangeStatus( Document $document ): bool {
+		// Only supported document types.
+		if ( ! in_array( $document->getDocumentType(), self::SUPPORTED_DOCUMENT_TYPES, true ) ) {
+			return false;
+		}
+
+		// Must have an order ID.
+		if ( ! $document->getOrderId() ) {
+			return false;
+		}
+
+		// Must be enabled in settings.
+		if ( ! $this->isEnabled() ) {
+			return false;
+		}
+
+		$order_id = $document->getOrderId();
+
+		/**
+		 * Filter whether automatic order status change should happen.
+		 *
+		 * @since 0.5.0
+		 *
+		 * @param bool     $enabled   Whether status change is enabled.
+		 * @param int      $order_id  WooCommerce order ID.
+		 * @param Document $document  The document being issued.
+		 */
+		return apply_filters( 'ihumbak_order_status_change_enabled', true, $order_id, $document );
+	}
+
+	/**
+	 * Get target status for a specific document.
+	 *
+	 * @param Document $document The document being issued.
+	 * @return string Target status.
+	 */
+	public function getTargetStatusForDocument( Document $document ): string {
+		$target_status = $this->getTargetStatus();
+		$order_id      = $document->getOrderId() ?? 0;
+
+		/**
+		 * Filter the target order status.
+		 *
+		 * @since 0.5.0
+		 *
+		 * @param string   $status    Target order status.
+		 * @param int      $order_id  WooCommerce order ID.
+		 * @param Document $document  The document being issued.
+		 */
+		return apply_filters( 'ihumbak_order_status_change_target', $target_status, $order_id, $document );
+	}
+
+	/**
+	 * Maybe change order status after document is issued.
+	 *
+	 * @param Document $document      The issued document.
+	 * @param bool     $user_confirmed Whether user confirmed status change via checkbox.
+	 * @return bool True if status was changed, false otherwise.
+	 */
+	public function maybeChangeOrderStatus( Document $document, bool $user_confirmed ): bool {
+		// User must confirm via checkbox.
+		if ( ! $user_confirmed ) {
+			return false;
+		}
+
+		// Check if change should happen.
+		if ( ! $this->shouldChangeStatus( $document ) ) {
+			return false;
+		}
+
+		$order_id = $document->getOrderId();
+		if ( ! $order_id ) {
+			return false;
+		}
+
+		// Get the order.
+		$order = wc_get_order( $order_id );
+		if ( ! $order ) {
+			return false;
+		}
+
+		$new_status = $this->getTargetStatusForDocument( $document );
+		$old_status = $order->get_status();
+
+		// Don't change if already at target status.
+		if ( $old_status === $new_status ) {
+			return false;
+		}
+
+		/**
+		 * Fires before order status is changed.
+		 *
+		 * @since 0.5.0
+		 *
+		 * @param int      $order_id   WooCommerce order ID.
+		 * @param string   $new_status New status being set.
+		 * @param Document $document   The issued document.
+		 */
+		do_action( 'ihumbak_before_order_status_change', $order_id, $new_status, $document );
+
+		// Change the status.
+		$order->update_status(
+			$new_status,
+			sprintf(
+				/* translators: %s: document number */
+				__( 'Order status changed after issuing document: %s', 'ihumbak-invoices' ),
+				$document->getDocumentNumber()
+			)
+		);
+
+		/**
+		 * Fires after order status is changed.
+		 *
+		 * @since 0.5.0
+		 *
+		 * @param int      $order_id   WooCommerce order ID.
+		 * @param string   $new_status New status that was set.
+		 * @param string   $old_status Previous order status.
+		 * @param Document $document   The issued document.
+		 */
+		do_action( 'ihumbak_after_order_status_change', $order_id, $new_status, $old_status, $document );
+
+		return true;
+	}
+
+	/**
+	 * Get default checkbox state for order status change.
+	 *
+	 * @param int|null $order_id WooCommerce order ID.
+	 * @return bool Default checked state.
+	 */
+	public function getCheckboxDefault( ?int $order_id ): bool {
+		// Default to checked if feature is enabled.
+		$default = $this->isEnabled();
+
+		/**
+		 * Filter the default checkbox state for order status change.
+		 *
+		 * @since 0.5.0
+		 *
+		 * @param bool     $checked   Default checked state.
+		 * @param int|null $order_id  WooCommerce order ID or null for new documents.
+		 */
+		return apply_filters( 'ihumbak_order_status_change_checkbox_default', $default, $order_id );
+	}
+
+	/**
+	 * Get target status label for display.
+	 *
+	 * @return string Status label.
+	 */
+	public function getTargetStatusLabel(): string {
+		$statuses      = $this->getOrderStatuses();
+		$target_status = $this->getTargetStatus();
+
+		return $statuses[ $target_status ] ?? $target_status;
+	}
+}

--- a/src/Modules/Invoice/OrderStatusService.php
+++ b/src/Modules/Invoice/OrderStatusService.php
@@ -28,14 +28,37 @@ class OrderStatusService {
 	);
 
 	/**
+	 * Cached order status settings.
+	 *
+	 * @var array<string, mixed>|null
+	 */
+	private ?array $order_status_settings = null;
+
+	/**
+	 * Get order status settings from plugin configuration.
+	 *
+	 * Settings are cached for performance optimization.
+	 *
+	 * @return array<string, mixed> Order status settings array.
+	 */
+	private function getOrderStatusSettings(): array {
+		if ( null === $this->order_status_settings ) {
+			$settings                    = Plugin::get_instance()->get_settings();
+			$this->order_status_settings = $settings['display']['order_status'] ?? array();
+		}
+
+		return $this->order_status_settings;
+	}
+
+	/**
 	 * Check if automatic order status change feature is enabled.
 	 *
 	 * @return bool True if enabled.
 	 */
 	public function isEnabled(): bool {
-		$settings = Plugin::get_instance()->get_settings();
+		$order_status_settings = $this->getOrderStatusSettings();
 
-		return ! empty( $settings['display']['order_status']['enabled'] );
+		return ! empty( $order_status_settings['enabled'] );
 	}
 
 	/**
@@ -44,9 +67,9 @@ class OrderStatusService {
 	 * @return string Target status (without 'wc-' prefix).
 	 */
 	public function getTargetStatus(): string {
-		$settings = Plugin::get_instance()->get_settings();
+		$order_status_settings = $this->getOrderStatusSettings();
 
-		return $settings['display']['order_status']['target'] ?? 'completed';
+		return $order_status_settings['target'] ?? 'completed';
 	}
 
 	/**
@@ -142,15 +165,12 @@ class OrderStatusService {
 			return false;
 		}
 
-		// Check if change should happen.
+		// Check if change should happen (includes order_id validation).
 		if ( ! $this->shouldChangeStatus( $document ) ) {
 			return false;
 		}
 
 		$order_id = $document->getOrderId();
-		if ( ! $order_id ) {
-			return false;
-		}
 
 		// Get the order.
 		$order = wc_get_order( $order_id );

--- a/stubs/woocommerce.stub
+++ b/stubs/woocommerce.stub
@@ -122,6 +122,15 @@ class WC_Order {
     public function get_shipping_method(): string {}
     /** @return WC_Order_Refund[] */
     public function get_refunds(): array {}
+    /**
+     * Update order status.
+     *
+     * @param string $new_status Status to change to (without wc- prefix).
+     * @param string $note       Optional order note.
+     * @param bool   $manual     Is this a manual status change.
+     * @return bool
+     */
+    public function update_status( string $new_status, string $note = '', bool $manual = false ): bool {}
 }
 
 class WC_Order_Item_Product {

--- a/templates/admin/invoice-edit.php
+++ b/templates/admin/invoice-edit.php
@@ -253,6 +253,11 @@ $page_title = $is_new
                                 <?php esc_html_e( 'Save and Issue', 'ihumbak-invoices' ); ?>
                             </button>
                         </p>
+                        <?php
+                        // Order status change checkbox.
+                        $order_id_value = $document ? $document->getOrderId() : ( $pre_filled_order_id ?? null );
+                        include IHUMBAK_INVOICES_PATH . 'templates/admin/partials/order-status-checkbox.php';
+                        ?>
                     <?php endif; ?>
 
                     <?php include IHUMBAK_INVOICES_PATH . 'templates/admin/partials/revert-button.php'; ?>

--- a/templates/admin/partials/order-status-checkbox.php
+++ b/templates/admin/partials/order-status-checkbox.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Order Status Change checkbox partial.
+ *
+ * Displays checkbox for changing order status when issuing a document.
+ *
+ * @package IHumbak\Invoices
+ *
+ * @var bool     $can_edit       Whether the document can be edited.
+ * @var int|null $order_id_value Current order ID value (from document or pre-filled).
+ */
+
+use IHumbak\Invoices\Modules\Invoice\OrderStatusService;
+
+defined( 'ABSPATH' ) || exit;
+
+// Create service instance.
+$order_status_service = new OrderStatusService();
+
+// Only render if feature is enabled.
+if ( ! $order_status_service->isEnabled() ) {
+	return;
+}
+
+// Only render if document can be edited.
+if ( empty( $can_edit ) ) {
+	return;
+}
+
+$target_status_label = $order_status_service->getTargetStatusLabel();
+$has_order_id        = ! empty( $order_id_value );
+$default_checked     = $order_status_service->getCheckboxDefault( $order_id_value );
+
+// Hidden by default if no order ID - will be shown via JS when order is selected.
+$wrapper_style = $has_order_id ? '' : 'display: none;';
+?>
+<div id="ihumbak-order-status-change-wrapper" class="ihumbak-order-status-change" style="<?php echo esc_attr( $wrapper_style ); ?>">
+	<hr style="margin: 15px 0;">
+	<p>
+		<label>
+			<input type="checkbox"
+				   id="change_order_status"
+				   name="change_order_status"
+				   value="1"
+				   <?php checked( $default_checked ); ?>>
+			<?php
+			printf(
+				/* translators: %s: target order status */
+				esc_html__( 'Change order status to "%s" when issuing', 'ihumbak-invoices' ),
+				esc_html( $target_status_label )
+			);
+			?>
+		</label>
+	</p>
+	<p class="description">
+		<?php esc_html_e( 'The order status will be changed automatically when you issue this document.', 'ihumbak-invoices' ); ?>
+	</p>
+</div>
+<?php

--- a/templates/admin/receipt-edit.php
+++ b/templates/admin/receipt-edit.php
@@ -241,6 +241,11 @@ $page_title = $is_new
                                 <?php esc_html_e( 'Save and Issue', 'ihumbak-invoices' ); ?>
                             </button>
                         </p>
+                        <?php
+                        // Order status change checkbox.
+                        $order_id_value = $document ? $document->getOrderId() : ( $pre_filled_order_id ?? null );
+                        include IHUMBAK_INVOICES_PATH . 'templates/admin/partials/order-status-checkbox.php';
+                        ?>
                     <?php endif; ?>
 
                     <?php include IHUMBAK_INVOICES_PATH . 'templates/admin/partials/revert-button.php'; ?>

--- a/templates/admin/settings.php
+++ b/templates/admin/settings.php
@@ -238,6 +238,53 @@ $active_tab = isset( $_GET['tab'] ) ? sanitize_text_field( wp_unslash( $_GET['ta
                 </tr>
             </table>
 
+            <h2><?php esc_html_e( 'Order Status Change', 'ihumbak-invoices' ); ?></h2>
+            <p class="description">
+                <?php esc_html_e( 'Configure automatic order status change when manually issuing invoices or receipts.', 'ihumbak-invoices' ); ?>
+            </p>
+
+            <?php
+            $order_status_service = new \IHumbak\Invoices\Modules\Invoice\OrderStatusService();
+            $order_statuses       = $order_status_service->getOrderStatuses();
+            $current_status       = $settings['display']['order_status']['target'] ?? 'completed';
+            $is_enabled           = ! empty( $settings['display']['order_status']['enabled'] );
+            ?>
+            <table class="form-table">
+                <tr>
+                    <th scope="row"><?php esc_html_e( 'Enable Status Change', 'ihumbak-invoices' ); ?></th>
+                    <td>
+                        <label>
+                            <input type="checkbox"
+                                   id="order_status_enabled"
+                                   name="ihumbak_invoices_settings[display][order_status][enabled]"
+                                   value="1"
+                                   <?php checked( $is_enabled ); ?>>
+                            <?php esc_html_e( 'Enable automatic order status change when generating documents', 'ihumbak-invoices' ); ?>
+                        </label>
+                        <p class="description">
+                            <?php esc_html_e( 'When enabled, a checkbox will appear on invoice/receipt edit pages allowing you to change the order status when issuing a document.', 'ihumbak-invoices' ); ?>
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row">
+                        <label for="order_status_target"><?php esc_html_e( 'Target Status', 'ihumbak-invoices' ); ?></label>
+                    </th>
+                    <td>
+                        <select id="order_status_target" name="ihumbak_invoices_settings[display][order_status][target]">
+                            <?php foreach ( $order_statuses as $status_slug => $status_label ) : ?>
+                                <option value="<?php echo esc_attr( $status_slug ); ?>" <?php selected( $current_status, $status_slug ); ?>>
+                                    <?php echo esc_html( $status_label ); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                        <p class="description">
+                            <?php esc_html_e( 'Select the order status to set when issuing a document.', 'ihumbak-invoices' ); ?>
+                        </p>
+                    </td>
+                </tr>
+            </table>
+
         <?php elseif ( 'permissions' === $active_tab ) : ?>
             <?php $current_role = $settings['permissions']['minimum_role'] ?? $permission_default_role; ?>
             <table class="form-table">

--- a/tests/Unit/Modules/Invoice/OrderStatusServiceTest.php
+++ b/tests/Unit/Modules/Invoice/OrderStatusServiceTest.php
@@ -1,0 +1,801 @@
+<?php
+/**
+ * OrderStatusService unit tests.
+ *
+ * @package IHumbak\Invoices\Tests\Unit\Modules\Invoice
+ */
+
+declare(strict_types=1);
+
+namespace IHumbak\Invoices\Tests\Unit\Modules\Invoice;
+
+use IHumbak\Invoices\Modules\Invoice\OrderStatusService;
+use IHumbak\Invoices\Models\Invoice;
+use IHumbak\Invoices\Models\Receipt;
+use IHumbak\Invoices\Models\CreditNote;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for OrderStatusService.
+ */
+class OrderStatusServiceTest extends TestCase {
+
+	/**
+	 * Service under test.
+	 *
+	 * @var OrderStatusService
+	 */
+	private OrderStatusService $service;
+
+	/**
+	 * Track action calls for testing.
+	 *
+	 * @var array<string, array<int, array<string, mixed>>>
+	 */
+	private array $action_calls = array();
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		// Reset options.
+		delete_option( 'ihumbak_invoices_settings' );
+
+		// Reset filters.
+		global $mock_wp_filters;
+		$mock_wp_filters = array();
+
+		// Reset WooCommerce orders.
+		global $mock_wc_orders;
+		$mock_wc_orders = array();
+
+		// Reset action calls tracking.
+		$this->action_calls = array();
+
+		// Reset Plugin singleton.
+		$this->resetPluginSingleton();
+
+		$this->service = new OrderStatusService();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	protected function tearDown(): void {
+		// Clean up options.
+		delete_option( 'ihumbak_invoices_settings' );
+
+		// Clean up filters.
+		global $mock_wp_filters;
+		$mock_wp_filters = array();
+
+		// Clean up WooCommerce orders.
+		global $mock_wc_orders;
+		$mock_wc_orders = array();
+
+		// Reset action calls.
+		$this->action_calls = array();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Reset Plugin singleton for testing.
+	 */
+	private function resetPluginSingleton(): void {
+		$reflection = new \ReflectionClass( \IHumbak\Invoices\Core\Plugin::class );
+		$property   = $reflection->getProperty( 'instance' );
+		$property->setAccessible( true );
+		$property->setValue( null, null );
+	}
+
+	/**
+	 * Create an Invoice document for testing.
+	 *
+	 * @param int|null $order_id Order ID.
+	 * @return Invoice
+	 */
+	private function createInvoice( ?int $order_id = null ): Invoice {
+		$invoice = new Invoice();
+		if ( null !== $order_id ) {
+			$invoice->setOrderId( $order_id );
+		}
+		$invoice->setDocumentNumber( 'FV/2024/01/0001' );
+		return $invoice;
+	}
+
+	/**
+	 * Create a Receipt document for testing.
+	 *
+	 * @param int|null $order_id Order ID.
+	 * @return Receipt
+	 */
+	private function createReceipt( ?int $order_id = null ): Receipt {
+		$receipt = new Receipt();
+		if ( null !== $order_id ) {
+			$receipt->setOrderId( $order_id );
+		}
+		$receipt->setDocumentNumber( 'PAR/2024/01/0001' );
+		return $receipt;
+	}
+
+	/**
+	 * Create a CreditNote document for testing.
+	 *
+	 * @param int|null $order_id Order ID.
+	 * @return CreditNote
+	 */
+	private function createCreditNote( ?int $order_id = null ): CreditNote {
+		$credit_note = new CreditNote();
+		if ( null !== $order_id ) {
+			$credit_note->setOrderId( $order_id );
+		}
+		$credit_note->setDocumentNumber( 'CN/2024/01/0001' );
+		return $credit_note;
+	}
+
+	/**
+	 * Enable order status change feature in settings.
+	 *
+	 * @param string $target_status Target status.
+	 */
+	private function enableOrderStatusFeature( string $target_status = 'completed' ): void {
+		update_option(
+			'ihumbak_invoices_settings',
+			array(
+				'display' => array(
+					'order_status' => array(
+						'enabled' => true,
+						'target'  => $target_status,
+					),
+				),
+			)
+		);
+
+		// Reset Plugin singleton to reload settings.
+		$this->resetPluginSingleton();
+		$this->service = new OrderStatusService();
+	}
+
+	/**
+	 * Disable order status change feature in settings.
+	 */
+	private function disableOrderStatusFeature(): void {
+		update_option(
+			'ihumbak_invoices_settings',
+			array(
+				'display' => array(
+					'order_status' => array(
+						'enabled' => false,
+						'target'  => 'completed',
+					),
+				),
+			)
+		);
+
+		// Reset Plugin singleton to reload settings.
+		$this->resetPluginSingleton();
+		$this->service = new OrderStatusService();
+	}
+
+	/**
+	 * Create a mock WC_Order for testing.
+	 *
+	 * @param int    $order_id Order ID.
+	 * @param string $status   Current order status (without 'wc-' prefix).
+	 * @return \WC_Order
+	 */
+	private function createMockOrder( int $order_id, string $status = 'processing' ): \WC_Order {
+		global $mock_wc_orders;
+
+		$order = new MockWCOrder();
+		$order->set_id( $order_id );
+		$order->set_status( $status );
+
+		$mock_wc_orders[ $order_id ] = $order;
+
+		return $order;
+	}
+
+	// ==========================================================================
+	// isEnabled() tests
+	// ==========================================================================
+
+	/**
+	 * Test isEnabled returns false when feature is disabled.
+	 */
+	public function test_is_enabled_returns_false_when_disabled(): void {
+		$this->disableOrderStatusFeature();
+
+		$this->assertFalse( $this->service->isEnabled() );
+	}
+
+	/**
+	 * Test isEnabled returns true when feature is enabled.
+	 */
+	public function test_is_enabled_returns_true_when_enabled(): void {
+		$this->enableOrderStatusFeature();
+
+		$this->assertTrue( $this->service->isEnabled() );
+	}
+
+	/**
+	 * Test isEnabled returns false when settings are empty.
+	 */
+	public function test_is_enabled_returns_false_when_settings_empty(): void {
+		delete_option( 'ihumbak_invoices_settings' );
+		$this->resetPluginSingleton();
+		$this->service = new OrderStatusService();
+
+		$this->assertFalse( $this->service->isEnabled() );
+	}
+
+	// ==========================================================================
+	// getTargetStatus() tests
+	// ==========================================================================
+
+	/**
+	 * Test getTargetStatus returns configured status.
+	 */
+	public function test_get_target_status_returns_configured_status(): void {
+		$this->enableOrderStatusFeature( 'on-hold' );
+
+		$this->assertSame( 'on-hold', $this->service->getTargetStatus() );
+	}
+
+	/**
+	 * Test getTargetStatus returns completed as default.
+	 */
+	public function test_get_target_status_returns_completed_by_default(): void {
+		delete_option( 'ihumbak_invoices_settings' );
+		$this->resetPluginSingleton();
+		$this->service = new OrderStatusService();
+
+		$this->assertSame( 'completed', $this->service->getTargetStatus() );
+	}
+
+	// ==========================================================================
+	// shouldChangeStatus() tests
+	// ==========================================================================
+
+	/**
+	 * Test shouldChangeStatus returns false for credit_note document type.
+	 */
+	public function test_should_change_status_returns_false_for_credit_note(): void {
+		$this->enableOrderStatusFeature();
+
+		$credit_note = $this->createCreditNote( 123 );
+
+		$this->assertFalse( $this->service->shouldChangeStatus( $credit_note ) );
+	}
+
+	/**
+	 * Test shouldChangeStatus returns false when document has no order_id.
+	 */
+	public function test_should_change_status_returns_false_when_no_order_id(): void {
+		$this->enableOrderStatusFeature();
+
+		$invoice = $this->createInvoice(); // No order_id.
+
+		$this->assertFalse( $this->service->shouldChangeStatus( $invoice ) );
+	}
+
+	/**
+	 * Test shouldChangeStatus returns false when feature is disabled.
+	 */
+	public function test_should_change_status_returns_false_when_feature_disabled(): void {
+		$this->disableOrderStatusFeature();
+
+		$invoice = $this->createInvoice( 123 );
+
+		$this->assertFalse( $this->service->shouldChangeStatus( $invoice ) );
+	}
+
+	/**
+	 * Test shouldChangeStatus returns true for invoice when all conditions met.
+	 */
+	public function test_should_change_status_returns_true_for_invoice_when_conditions_met(): void {
+		$this->enableOrderStatusFeature();
+
+		$invoice = $this->createInvoice( 123 );
+
+		$this->assertTrue( $this->service->shouldChangeStatus( $invoice ) );
+	}
+
+	/**
+	 * Test shouldChangeStatus returns true for receipt when all conditions met.
+	 */
+	public function test_should_change_status_returns_true_for_receipt_when_conditions_met(): void {
+		$this->enableOrderStatusFeature();
+
+		$receipt = $this->createReceipt( 123 );
+
+		$this->assertTrue( $this->service->shouldChangeStatus( $receipt ) );
+	}
+
+	/**
+	 * Test ihumbak_order_status_change_enabled filter can override to false.
+	 */
+	public function test_should_change_status_filter_can_override_to_false(): void {
+		$this->enableOrderStatusFeature();
+
+		$invoice = $this->createInvoice( 123 );
+
+		// Add filter to deny status change.
+		add_filter( 'ihumbak_order_status_change_enabled', '__return_false' );
+
+		$this->assertFalse( $this->service->shouldChangeStatus( $invoice ) );
+
+		// Clean up.
+		remove_filter( 'ihumbak_order_status_change_enabled', '__return_false' );
+	}
+
+	/**
+	 * Test ihumbak_order_status_change_enabled filter receives correct parameters.
+	 */
+	public function test_should_change_status_filter_receives_correct_parameters(): void {
+		$this->enableOrderStatusFeature();
+
+		$invoice  = $this->createInvoice( 456 );
+		$received = array();
+
+		$callback = function ( $enabled, $order_id, $document ) use ( &$received ) {
+			$received = array(
+				'enabled'  => $enabled,
+				'order_id' => $order_id,
+				'document' => $document,
+			);
+			return $enabled;
+		};
+
+		add_filter( 'ihumbak_order_status_change_enabled', $callback, 10, 3 );
+
+		$this->service->shouldChangeStatus( $invoice );
+
+		$this->assertTrue( $received['enabled'] );
+		$this->assertSame( 456, $received['order_id'] );
+		$this->assertSame( $invoice, $received['document'] );
+
+		// Clean up.
+		remove_filter( 'ihumbak_order_status_change_enabled', $callback );
+	}
+
+	// ==========================================================================
+	// maybeChangeOrderStatus() tests
+	// ==========================================================================
+
+	/**
+	 * Test maybeChangeOrderStatus returns false when user_confirmed is false.
+	 */
+	public function test_maybe_change_order_status_returns_false_when_not_confirmed(): void {
+		$this->enableOrderStatusFeature();
+
+		$invoice = $this->createInvoice( 123 );
+		$this->createMockOrder( 123, 'processing' );
+
+		$result = $this->service->maybeChangeOrderStatus( $invoice, false );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test maybeChangeOrderStatus returns false when shouldChangeStatus returns false.
+	 */
+	public function test_maybe_change_order_status_returns_false_when_should_change_returns_false(): void {
+		$this->disableOrderStatusFeature();
+
+		$invoice = $this->createInvoice( 123 );
+		$this->createMockOrder( 123, 'processing' );
+
+		$result = $this->service->maybeChangeOrderStatus( $invoice, true );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test maybeChangeOrderStatus returns false when order does not exist.
+	 */
+	public function test_maybe_change_order_status_returns_false_when_order_not_found(): void {
+		$this->enableOrderStatusFeature();
+
+		$invoice = $this->createInvoice( 999 ); // Order 999 does not exist.
+
+		$result = $this->service->maybeChangeOrderStatus( $invoice, true );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test maybeChangeOrderStatus returns false when order already has target status.
+	 */
+	public function test_maybe_change_order_status_returns_false_when_already_target_status(): void {
+		$this->enableOrderStatusFeature( 'completed' );
+
+		$invoice = $this->createInvoice( 123 );
+		$this->createMockOrder( 123, 'completed' ); // Already at target status.
+
+		$result = $this->service->maybeChangeOrderStatus( $invoice, true );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test maybeChangeOrderStatus returns true and changes status when all conditions met.
+	 */
+	public function test_maybe_change_order_status_returns_true_when_conditions_met(): void {
+		$this->enableOrderStatusFeature( 'completed' );
+
+		$invoice = $this->createInvoice( 123 );
+		$order   = $this->createMockOrder( 123, 'processing' );
+
+		$result = $this->service->maybeChangeOrderStatus( $invoice, true );
+
+		$this->assertTrue( $result );
+		$this->assertSame( 'completed', $order->get_status() );
+	}
+
+	/**
+	 * Test maybeChangeOrderStatus fires before and after actions.
+	 */
+	public function test_maybe_change_order_status_fires_actions(): void {
+		$this->enableOrderStatusFeature( 'completed' );
+
+		$invoice = $this->createInvoice( 123 );
+		$invoice->setDocumentNumber( 'FV/2024/01/0001' );
+		$this->createMockOrder( 123, 'processing' );
+
+		$before_fired = false;
+		$after_fired  = false;
+		$before_args  = array();
+		$after_args   = array();
+
+		// Override do_action to track calls.
+		$original_do_action = null;
+
+		// Create a custom callback to track action calls.
+		$track_actions = function ( $tag, ...$args ) use ( &$before_fired, &$after_fired, &$before_args, &$after_args ) {
+			if ( 'ihumbak_before_order_status_change' === $tag ) {
+				$before_fired = true;
+				$before_args  = $args;
+			}
+			if ( 'ihumbak_after_order_status_change' === $tag ) {
+				$after_fired = true;
+				$after_args  = $args;
+			}
+		};
+
+		// We need to override do_action temporarily.
+		// Since the mock do_action is defined in bootstrap.php, we'll test the behavior differently.
+		// The actions are called but the mock do_action does nothing.
+		// We can verify the behavior by checking the method execution path.
+		$result = $this->service->maybeChangeOrderStatus( $invoice, true );
+
+		// Since do_action is mocked to do nothing, we can only verify that the method returned true.
+		// The actions would be fired in a real WordPress environment.
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test maybeChangeOrderStatus updates order status with correct note.
+	 */
+	public function test_maybe_change_order_status_updates_with_correct_note(): void {
+		$this->enableOrderStatusFeature( 'completed' );
+
+		$invoice = $this->createInvoice( 123 );
+		$invoice->setDocumentNumber( 'FV/2024/01/0001' );
+		$order = $this->createMockOrder( 123, 'processing' );
+
+		$this->service->maybeChangeOrderStatus( $invoice, true );
+
+		// Verify the status note contains the document number.
+		$note = $order->get_last_status_note();
+		$this->assertStringContainsString( 'FV/2024/01/0001', $note );
+	}
+
+	// ==========================================================================
+	// getCheckboxDefault() tests
+	// ==========================================================================
+
+	/**
+	 * Test getCheckboxDefault returns true when feature is enabled.
+	 */
+	public function test_get_checkbox_default_returns_true_when_enabled(): void {
+		$this->enableOrderStatusFeature();
+
+		$result = $this->service->getCheckboxDefault( 123 );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test getCheckboxDefault returns false when feature is disabled.
+	 */
+	public function test_get_checkbox_default_returns_false_when_disabled(): void {
+		$this->disableOrderStatusFeature();
+
+		$result = $this->service->getCheckboxDefault( 123 );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test getCheckboxDefault handles null order_id.
+	 */
+	public function test_get_checkbox_default_handles_null_order_id(): void {
+		$this->enableOrderStatusFeature();
+
+		$result = $this->service->getCheckboxDefault( null );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test ihumbak_order_status_change_checkbox_default filter can override to false.
+	 */
+	public function test_get_checkbox_default_filter_can_override_to_false(): void {
+		$this->enableOrderStatusFeature();
+
+		add_filter( 'ihumbak_order_status_change_checkbox_default', '__return_false' );
+
+		$result = $this->service->getCheckboxDefault( 123 );
+
+		$this->assertFalse( $result );
+
+		// Clean up.
+		remove_filter( 'ihumbak_order_status_change_checkbox_default', '__return_false' );
+	}
+
+	/**
+	 * Test ihumbak_order_status_change_checkbox_default filter can override to true.
+	 */
+	public function test_get_checkbox_default_filter_can_override_to_true(): void {
+		$this->disableOrderStatusFeature();
+
+		add_filter( 'ihumbak_order_status_change_checkbox_default', '__return_true' );
+
+		$result = $this->service->getCheckboxDefault( 123 );
+
+		$this->assertTrue( $result );
+
+		// Clean up.
+		remove_filter( 'ihumbak_order_status_change_checkbox_default', '__return_true' );
+	}
+
+	/**
+	 * Test ihumbak_order_status_change_checkbox_default filter receives correct parameters.
+	 */
+	public function test_get_checkbox_default_filter_receives_correct_parameters(): void {
+		$this->enableOrderStatusFeature();
+
+		$received = array();
+
+		$callback = function ( $checked, $order_id ) use ( &$received ) {
+			$received = array(
+				'checked'  => $checked,
+				'order_id' => $order_id,
+			);
+			return $checked;
+		};
+
+		add_filter( 'ihumbak_order_status_change_checkbox_default', $callback, 10, 2 );
+
+		$this->service->getCheckboxDefault( 789 );
+
+		$this->assertTrue( $received['checked'] );
+		$this->assertSame( 789, $received['order_id'] );
+
+		// Clean up.
+		remove_filter( 'ihumbak_order_status_change_checkbox_default', $callback );
+	}
+
+	// ==========================================================================
+	// getTargetStatusForDocument() tests
+	// ==========================================================================
+
+	/**
+	 * Test getTargetStatusForDocument returns configured target status.
+	 */
+	public function test_get_target_status_for_document_returns_configured_status(): void {
+		$this->enableOrderStatusFeature( 'on-hold' );
+
+		$invoice = $this->createInvoice( 123 );
+
+		$result = $this->service->getTargetStatusForDocument( $invoice );
+
+		$this->assertSame( 'on-hold', $result );
+	}
+
+	/**
+	 * Test ihumbak_order_status_change_target filter can override the status.
+	 */
+	public function test_get_target_status_for_document_filter_can_override(): void {
+		$this->enableOrderStatusFeature( 'completed' );
+
+		$invoice = $this->createInvoice( 123 );
+
+		$callback = function ( $status, $order_id, $document ) {
+			return 'custom-status';
+		};
+
+		add_filter( 'ihumbak_order_status_change_target', $callback, 10, 3 );
+
+		$result = $this->service->getTargetStatusForDocument( $invoice );
+
+		$this->assertSame( 'custom-status', $result );
+
+		// Clean up.
+		remove_filter( 'ihumbak_order_status_change_target', $callback );
+	}
+
+	/**
+	 * Test ihumbak_order_status_change_target filter receives correct parameters.
+	 */
+	public function test_get_target_status_for_document_filter_receives_correct_parameters(): void {
+		$this->enableOrderStatusFeature( 'completed' );
+
+		$invoice  = $this->createInvoice( 456 );
+		$received = array();
+
+		$callback = function ( $status, $order_id, $document ) use ( &$received ) {
+			$received = array(
+				'status'   => $status,
+				'order_id' => $order_id,
+				'document' => $document,
+			);
+			return $status;
+		};
+
+		add_filter( 'ihumbak_order_status_change_target', $callback, 10, 3 );
+
+		$this->service->getTargetStatusForDocument( $invoice );
+
+		$this->assertSame( 'completed', $received['status'] );
+		$this->assertSame( 456, $received['order_id'] );
+		$this->assertSame( $invoice, $received['document'] );
+
+		// Clean up.
+		remove_filter( 'ihumbak_order_status_change_target', $callback );
+	}
+
+	/**
+	 * Test getTargetStatusForDocument handles document without order_id.
+	 */
+	public function test_get_target_status_for_document_handles_no_order_id(): void {
+		$this->enableOrderStatusFeature( 'completed' );
+
+		$invoice = $this->createInvoice(); // No order_id.
+
+		$received_order_id = null;
+
+		$callback = function ( $status, $order_id, $document ) use ( &$received_order_id ) {
+			$received_order_id = $order_id;
+			return $status;
+		};
+
+		add_filter( 'ihumbak_order_status_change_target', $callback, 10, 3 );
+
+		$result = $this->service->getTargetStatusForDocument( $invoice );
+
+		$this->assertSame( 'completed', $result );
+		$this->assertSame( 0, $received_order_id ); // Should be 0 when null.
+
+		// Clean up.
+		remove_filter( 'ihumbak_order_status_change_target', $callback );
+	}
+
+	// ==========================================================================
+	// getOrderStatuses() tests
+	// ==========================================================================
+
+	/**
+	 * Test getOrderStatuses returns array.
+	 */
+	public function test_get_order_statuses_returns_array(): void {
+		$result = $this->service->getOrderStatuses();
+
+		$this->assertIsArray( $result );
+	}
+
+	// ==========================================================================
+	// getTargetStatusLabel() tests
+	// ==========================================================================
+
+	/**
+	 * Test getTargetStatusLabel returns status when no label found.
+	 */
+	public function test_get_target_status_label_returns_status_when_no_label(): void {
+		$this->enableOrderStatusFeature( 'custom-status' );
+
+		$result = $this->service->getTargetStatusLabel();
+
+		$this->assertSame( 'custom-status', $result );
+	}
+}
+
+/**
+ * Mock WC_Order class with additional methods for testing.
+ */
+class MockWCOrder extends \WC_Order {
+
+	/**
+	 * Order ID.
+	 *
+	 * @var int
+	 */
+	private int $id = 0;
+
+	/**
+	 * Order status.
+	 *
+	 * @var string
+	 */
+	private string $status = 'pending';
+
+	/**
+	 * Last status update note.
+	 *
+	 * @var string
+	 */
+	private string $last_status_note = '';
+
+	/**
+	 * Set order ID.
+	 *
+	 * @param int $id Order ID.
+	 */
+	public function set_id( int $id ): void {
+		$this->id = $id;
+	}
+
+	/**
+	 * Get order ID.
+	 *
+	 * @return int
+	 */
+	public function get_id(): int {
+		return $this->id;
+	}
+
+	/**
+	 * Set order status.
+	 *
+	 * @param string $status Order status.
+	 */
+	public function set_status( string $status ): void {
+		$this->status = $status;
+	}
+
+	/**
+	 * Get order status.
+	 *
+	 * @return string
+	 */
+	public function get_status(): string {
+		return $this->status;
+	}
+
+	/**
+	 * Update order status.
+	 *
+	 * @param string $new_status New status.
+	 * @param string $note       Status change note.
+	 * @param bool   $manual     Manual update flag.
+	 * @return bool
+	 */
+	public function update_status( string $new_status, string $note = '', bool $manual = false ): bool {
+		$this->status           = str_replace( 'wc-', '', $new_status );
+		$this->last_status_note = $note;
+		return true;
+	}
+
+	/**
+	 * Get the last status change note.
+	 *
+	 * @return string
+	 */
+	public function get_last_status_note(): string {
+		return $this->last_status_note;
+	}
+}


### PR DESCRIPTION
## Summary

- Add functionality to automatically change WooCommerce order status when manually issuing invoices or receipts
- New `OrderStatusService` class with full hooks support for customization
- Settings UI in Display tab with enable checkbox and target status dropdown
- Checkbox partial template shown on invoice/receipt edit pages when order is linked
- JavaScript for dynamic checkbox visibility based on order ID field

## Changes

### New Files
- `src/Modules/Invoice/OrderStatusService.php` - Service class for status change logic
- `templates/admin/partials/order-status-checkbox.php` - Checkbox partial template

### Modified Files
- `src/Core/Plugin.php` - Default settings and sanitization for order_status
- `src/Modules/Admin/DocumentController.php` - Trigger status change after document issue
- `templates/admin/settings.php` - Settings UI in Display tab
- `templates/admin/invoice-edit.php` - Include checkbox partial
- `templates/admin/receipt-edit.php` - Include checkbox partial
- `assets/js/document-edit.js` - Dynamic checkbox visibility
- `docs/HOOKS-API.md` - Document new hooks
- `stubs/woocommerce.stub` - Add update_status method for PHPStan

## New Hooks

**Actions:**
- `ihumbak_before_order_status_change` - Before status change
- `ihumbak_after_order_status_change` - After status change

**Filters:**
- `ihumbak_order_status_change_enabled` - Override if status change should happen
- `ihumbak_order_status_change_target` - Override target status
- `ihumbak_order_status_change_checkbox_default` - Change default checkbox state

## Test plan

- [ ] Enable feature in Settings > Display > Order Status Change
- [ ] Select target status (e.g., "Completed")
- [ ] Create new invoice linked to an order - checkbox should appear
- [ ] Issue invoice with checkbox checked - order status should change
- [ ] Issue invoice with checkbox unchecked - order status should NOT change
- [ ] Save as draft - order status should NOT change regardless of checkbox
- [ ] Verify checkbox is hidden when no order ID is entered
- [ ] Test with receipt (same behavior expected)

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)