### PR TITLE
feat(email): add admin email copy for debugging document delivery

### DIFF
--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -800,6 +800,8 @@ final class Plugin {
 				'auto_send_receipt'        => false,
 				'auto_send_credit_note'    => false,
 				'auto_send_receipt_return' => false,
+				'send_copy_to_admin'       => false,
+				'admin_email_addresses'    => '',
 			),
 		);
 	}
@@ -891,11 +893,23 @@ final class Plugin {
 
 		// Sanitize email settings.
 		if ( isset( $input['email'] ) && is_array( $input['email'] ) ) {
+			// Sanitize comma-separated admin email addresses.
+			$admin_emails = '';
+			if ( ! empty( $input['email']['admin_email_addresses'] ) ) {
+				$raw_emails       = sanitize_text_field( $input['email']['admin_email_addresses'] );
+				$email_array      = array_map( 'trim', explode( ',', $raw_emails ) );
+				$valid_emails     = array_filter( $email_array, 'is_email' );
+				$sanitized_emails = array_map( 'sanitize_email', $valid_emails );
+				$admin_emails     = implode( ', ', $sanitized_emails );
+			}
+
 			$sanitized['email'] = array(
 				'auto_send_invoice'        => ! empty( $input['email']['auto_send_invoice'] ),
 				'auto_send_receipt'        => ! empty( $input['email']['auto_send_receipt'] ),
 				'auto_send_credit_note'    => ! empty( $input['email']['auto_send_credit_note'] ),
 				'auto_send_receipt_return' => ! empty( $input['email']['auto_send_receipt_return'] ),
+				'send_copy_to_admin'       => ! empty( $input['email']['send_copy_to_admin'] ),
+				'admin_email_addresses'    => $admin_emails,
 			);
 		}
 

--- a/src/Modules/Email/EmailService.php
+++ b/src/Modules/Email/EmailService.php
@@ -133,6 +133,9 @@ class EmailService {
 
 			// Update document status to sent.
 			$this->updateDocumentStatus( $document );
+
+			// Send admin copy if enabled.
+			$this->sendAdminCopy( $document, $email );
 		} else {
 			do_action( 'ihumbak_email_failed', $document, __( 'Email sending failed.', 'ihumbak-invoices' ) );
 		}
@@ -254,6 +257,76 @@ class EmailService {
 		}
 
 		$this->getDocumentRepository()->save( $document );
+	}
+
+	/**
+	 * Send admin copy of the document email for debugging purposes.
+	 *
+	 * @param Document              $document The document.
+	 * @param AbstractDocumentEmail $email    The email instance used for the customer email.
+	 * @return void
+	 */
+	private function sendAdminCopy( Document $document, AbstractDocumentEmail $email ): void {
+		$settings = Plugin::get_instance()->get_settings();
+
+		// Check if admin copy is enabled.
+		if ( empty( $settings['email']['send_copy_to_admin'] ) ) {
+			return;
+		}
+
+		// Get admin email addresses.
+		$admin_emails_string = $settings['email']['admin_email_addresses'] ?? '';
+		if ( empty( $admin_emails_string ) ) {
+			return;
+		}
+
+		// Parse comma-separated emails.
+		$admin_emails = array_map( 'trim', explode( ',', $admin_emails_string ) );
+		$admin_emails = array_filter( $admin_emails, 'is_email' );
+
+		if ( empty( $admin_emails ) ) {
+			return;
+		}
+
+		// Generate PDF attachment for admin copy.
+		$pdf_path = $this->generatePdfAttachment( $document );
+		if ( ! $pdf_path || ! file_exists( $pdf_path ) ) {
+			return;
+		}
+
+		// Prepare email content.
+		$subject = sprintf(
+			/* translators: %s: original email subject */
+			__( 'Debug mode: %s', 'ihumbak-invoices' ),
+			$email->get_subject()
+		);
+
+		$content = $email->get_content();
+		$headers = $email->get_headers();
+
+		// Send to each admin address.
+		foreach ( $admin_emails as $admin_email ) {
+			$result = $email->send(
+				$admin_email,
+				$subject,
+				$content,
+				$headers,
+				array( $pdf_path )
+			);
+
+			/**
+			 * Fires after admin copy email is sent.
+			 *
+			 * @param Document $document    The document.
+			 * @param string   $admin_email Admin email address.
+			 * @param bool     $result      Whether email was sent successfully.
+			 */
+			do_action( 'ihumbak_admin_copy_sent', $document, $admin_email, $result );
+		}
+
+		// Clean up temp PDF file.
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Cleanup temp file.
+		unlink( $pdf_path );
 	}
 
 	/**

--- a/templates/admin/settings.php
+++ b/templates/admin/settings.php
@@ -368,6 +368,34 @@ $active_tab = isset( $_GET['tab'] ) ? sanitize_text_field( wp_unslash( $_GET['ta
                         </label>
                     </td>
                 </tr>
+                <tr>
+                    <th scope="row"><?php esc_html_e( 'Send Copy to Admin', 'ihumbak-invoices' ); ?></th>
+                    <td>
+                        <label>
+                            <input type="checkbox"
+                                   name="ihumbak_invoices_settings[email][send_copy_to_admin]"
+                                   value="1"
+                                   <?php checked( ! empty( $settings['email']['send_copy_to_admin'] ) ); ?>>
+                            <?php esc_html_e( 'Send a copy of all document emails to admin addresses', 'ihumbak-invoices' ); ?>
+                        </label>
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row">
+                        <label for="admin_email_addresses"><?php esc_html_e( 'Admin Email Address(es)', 'ihumbak-invoices' ); ?></label>
+                    </th>
+                    <td>
+                        <input type="text"
+                               id="admin_email_addresses"
+                               name="ihumbak_invoices_settings[email][admin_email_addresses]"
+                               value="<?php echo esc_attr( $settings['email']['admin_email_addresses'] ?? '' ); ?>"
+                               class="regular-text"
+                               placeholder="<?php esc_attr_e( 'admin@example.com, billing@example.com', 'ihumbak-invoices' ); ?>">
+                        <p class="description">
+                            <?php esc_html_e( 'Enter email addresses separated by commas. Leave empty to disable.', 'ihumbak-invoices' ); ?>
+                        </p>
+                    </td>
+                </tr>
             </table>
 
             <div class="notice notice-info inline" style="margin: 20px 0;">


### PR DESCRIPTION
## Summary

- Add "Send copy to admin" checkbox in Email settings tab
- Add "Admin email addresses" field supporting comma-separated emails
- Send identical email copy to admin(s) with "Debug mode: " subject prefix
- Add `ihumbak_admin_copy_sent` action hook for extensibility

Closes #30

## Test plan

- [ ] Enable "Send copy to admin" in settings
- [ ] Enter one or more comma-separated email addresses
- [ ] Issue a document (invoice, receipt, etc.) with auto-send enabled
- [ ] Verify admin receives email with "Debug mode: " prefix in subject
- [ ] Verify PDF attachment is included
- [ ] Test with invalid emails in the list (should be filtered out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)