### PR TITLE
feat(numbering): add manual counter adjustment for super-admins

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -114,6 +114,160 @@
     };
 
     /**
+     * Counter adjustment handler for super-admins.
+     */
+    var counterAdjustmentHandler = {
+        init: function() {
+            var $table = $('#ihumbak-numbering-adjustment');
+            if (!$table.length) {
+                return;
+            }
+
+            this.$table = $table;
+            this.$loading = $('#ihumbak-numbering-loading');
+            this.loadCounterStates();
+        },
+
+        loadCounterStates: function() {
+            var self = this;
+
+            $.ajax({
+                url: ihumbakInvoices.ajaxUrl,
+                type: 'POST',
+                data: {
+                    action: 'ihumbak_get_numbering_state',
+                    nonce: ihumbakInvoices.nonce
+                },
+                success: function(response) {
+                    self.$loading.hide();
+                    if (response.success) {
+                        self.renderTable(response.data);
+                    } else {
+                        self.showError(response.data.message || ihumbakInvoices.i18n.error);
+                    }
+                },
+                error: function() {
+                    self.$loading.hide();
+                    self.showError(ihumbakInvoices.i18n.error);
+                }
+            });
+        },
+
+        renderTable: function(states) {
+            var self = this;
+            var $tbody = this.$table.find('tbody');
+            $tbody.empty();
+
+            $.each(states, function(type, state) {
+                var $row = $('<tr></tr>');
+
+                // Label column.
+                $row.append(
+                    $('<th scope="row"></th>').text(state.label)
+                );
+
+                // Input and button column.
+                var $td = $('<td></td>');
+
+                var periodInfo = state.month
+                    ? state.year + '/' + String(state.month).padStart(2, '0')
+                    : state.year;
+
+                $td.append(
+                    $('<span class="description" style="margin-right: 10px;"></span>')
+                        .text('(' + periodInfo + ') ')
+                );
+
+                $td.append(
+                    $('<label style="margin-right: 5px;"></label>')
+                        .text(ihumbakInvoices.i18n.nextNumber + ': ')
+                );
+
+                var $input = $('<input type="number">')
+                    .attr('id', 'counter-' + type)
+                    .attr('min', state.min_allowed)
+                    .attr('step', 1)
+                    .val(state.current_next)
+                    .css({width: '100px', marginRight: '10px'})
+                    .data('original', state.current_next)
+                    .data('type', type);
+
+                $td.append($input);
+
+                var $button = $('<button type="button" class="button"></button>')
+                    .text(ihumbakInvoices.i18n.adjust)
+                    .data('type', type)
+                    .on('click', function() {
+                        self.handleAdjust(type, $input);
+                    });
+
+                $td.append($button);
+
+                $row.append($td);
+                $tbody.append($row);
+            });
+        },
+
+        handleAdjust: function(type, $input) {
+            var self = this;
+            var newValue = parseInt($input.val(), 10);
+            var originalValue = $input.data('original');
+
+            if (isNaN(newValue) || newValue < 1) {
+                alert(ihumbakInvoices.i18n.numberTooLow);
+                return;
+            }
+
+            if (newValue === originalValue) {
+                return;
+            }
+
+            var confirmMsg = ihumbakInvoices.i18n.confirmAdjust
+                .replace('%1$d', originalValue)
+                .replace('%2$d', newValue);
+
+            if (!confirm(confirmMsg)) {
+                $input.val(originalValue);
+                return;
+            }
+
+            $input.prop('disabled', true);
+
+            $.ajax({
+                url: ihumbakInvoices.ajaxUrl,
+                type: 'POST',
+                data: {
+                    action: 'ihumbak_adjust_numbering',
+                    nonce: ihumbakInvoices.nonce,
+                    document_type: type,
+                    next_number: newValue
+                },
+                success: function(response) {
+                    $input.prop('disabled', false);
+                    if (response.success) {
+                        $input.data('original', newValue);
+                        alert(ihumbakInvoices.i18n.counterAdjusted);
+                    } else {
+                        alert(response.data.message || ihumbakInvoices.i18n.error);
+                        $input.val(originalValue);
+                    }
+                },
+                error: function() {
+                    $input.prop('disabled', false);
+                    alert(ihumbakInvoices.i18n.error);
+                    $input.val(originalValue);
+                }
+            });
+        },
+
+        showError: function(message) {
+            this.$table.find('tbody').html(
+                '<tr><td colspan="2" style="color: #d63638;">' + message + '</td></tr>'
+            );
+        }
+    };
+
+    /**
      * Initialize on document ready.
      */
     $(document).ready(function() {
@@ -127,6 +281,9 @@
 
         // Initialize resend email handler.
         resendEmailHandler.init();
+
+        // Initialize counter adjustment handler.
+        counterAdjustmentHandler.init();
     });
 
 })(jQuery);

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -143,7 +143,12 @@
                     if (response.success) {
                         self.renderTable(response.data);
                     } else {
-                        self.showError(response.data.message || ihumbakInvoices.i18n.error);
+                        var message = response.data.message || ihumbakInvoices.i18n.error;
+                        if (message.toLowerCase().indexOf('nonce') !== -1 ||
+                            message.toLowerCase().indexOf('session') !== -1) {
+                            message = ihumbakInvoices.i18n.sessionExpired || 'Session expired. Please refresh the page.';
+                        }
+                        self.showError(message);
                     }
                 },
                 error: function() {
@@ -248,7 +253,12 @@
                         $input.data('original', newValue);
                         alert(ihumbakInvoices.i18n.counterAdjusted);
                     } else {
-                        alert(response.data.message || ihumbakInvoices.i18n.error);
+                        var message = response.data.message || ihumbakInvoices.i18n.error;
+                        if (message.toLowerCase().indexOf('nonce') !== -1 ||
+                            message.toLowerCase().indexOf('session') !== -1) {
+                            message = ihumbakInvoices.i18n.sessionExpired || 'Session expired. Please refresh the page.';
+                        }
+                        alert(message);
                         $input.val(originalValue);
                     }
                 },
@@ -261,9 +271,8 @@
         },
 
         showError: function(message) {
-            this.$table.find('tbody').html(
-                '<tr><td colspan="2" style="color: #d63638;">' + message + '</td></tr>'
-            );
+            var $cell = $('<td colspan="2" style="color: #d63638;"></td>').text(message);
+            this.$table.find('tbody').html($('<tr></tr>').append($cell));
         }
     };
 

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -435,6 +435,13 @@ final class Plugin {
 					'nameRequiredError'      => __( 'Please enter a product name for all items with values.', 'ihumbak-invoices' ),
 					'vatRequiredError'       => __( 'Please enter a VAT rate for all items.', 'ihumbak-invoices' ),
 					'selectOriginalDocument' => __( 'Please select the original document to correct.', 'ihumbak-invoices' ),
+					'adjust'                 => __( 'Adjust', 'ihumbak-invoices' ),
+					'nextNumber'             => __( 'Next number', 'ihumbak-invoices' ),
+					'minAllowed'             => __( 'Minimum allowed', 'ihumbak-invoices' ),
+					'numberTooLow'           => __( 'The next number must be at least 1.', 'ihumbak-invoices' ),
+					/* translators: %1$d: current next number, %2$d: new next number */
+					'confirmAdjust'          => __( 'Are you sure you want to change the next number from %1$d to %2$d?', 'ihumbak-invoices' ),
+					'counterAdjusted'        => __( 'Counter adjusted successfully.', 'ihumbak-invoices' ),
 				),
 			)
 		);

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -442,6 +442,7 @@ final class Plugin {
 					/* translators: %1$d: current next number, %2$d: new next number */
 					'confirmAdjust'          => __( 'Are you sure you want to change the next number from %1$d to %2$d?', 'ihumbak-invoices' ),
 					'counterAdjusted'        => __( 'Counter adjusted successfully.', 'ihumbak-invoices' ),
+					'sessionExpired'         => __( 'Session expired. Please refresh the page.', 'ihumbak-invoices' ),
 				),
 			)
 		);

--- a/src/Modules/Admin/AjaxController.php
+++ b/src/Modules/Admin/AjaxController.php
@@ -494,6 +494,24 @@ class AjaxController {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- absint sanitizes.
 		$next_number = isset( $_POST['next_number'] ) ? absint( wp_unslash( $_POST['next_number'] ) ) : 0;
 
+		/**
+		 * Fires when a numbering adjustment is attempted.
+		 *
+		 * Useful for logging all adjustment attempts, including failed ones.
+		 *
+		 * @since 0.5.7
+		 *
+		 * @param string $document_type Requested document type.
+		 * @param int    $next_number   Requested next number.
+		 * @param int    $user_id       ID of the user attempting the adjustment.
+		 */
+		do_action(
+			'ihumbak_numbering_adjustment_attempted',
+			$document_type,
+			$next_number,
+			get_current_user_id()
+		);
+
 		// Validate document type.
 		$valid_types = array( 'invoice', 'receipt', 'credit_note', 'receipt_return' );
 		if ( ! in_array( $document_type, $valid_types, true ) ) {

--- a/src/Modules/Admin/AjaxController.php
+++ b/src/Modules/Admin/AjaxController.php
@@ -13,6 +13,7 @@ use IHumbak\Invoices\Modules\Invoice\CalculationService;
 use IHumbak\Invoices\Modules\Invoice\NumberingService;
 use IHumbak\Invoices\Modules\Invoice\OrderDataExtractor;
 use IHumbak\Invoices\Modules\Invoice\RefundDataExtractor;
+use IHumbak\Invoices\Modules\Invoice\SuperAdminService;
 use IHumbak\Invoices\Infrastructure\Database\DocumentRepository;
 use IHumbak\Invoices\Infrastructure\Database\DocumentItemRepository;
 use IHumbak\Invoices\Core\Plugin;
@@ -74,6 +75,8 @@ class AjaxController {
 		add_action( 'wp_ajax_ihumbak_fetch_invoice_data', array( $this, 'fetch_invoice_data' ) );
 		add_action( 'wp_ajax_ihumbak_fetch_receipt_data', array( $this, 'fetch_receipt_data' ) );
 		add_action( 'wp_ajax_ihumbak_fetch_refund_data', array( $this, 'fetch_refund_data' ) );
+		add_action( 'wp_ajax_ihumbak_get_numbering_state', array( $this, 'get_numbering_state' ) );
+		add_action( 'wp_ajax_ihumbak_adjust_numbering', array( $this, 'adjust_numbering' ) );
 	}
 
 	/**
@@ -432,5 +435,112 @@ class AjaxController {
 		}
 
 		wp_send_json_success( $refund_data );
+	}
+
+	/**
+	 * Get numbering state for all document types.
+	 *
+	 * Returns current counter state for super-admins to view and manage.
+	 *
+	 * @return void
+	 */
+	public function get_numbering_state(): void {
+		check_ajax_referer( 'ihumbak_invoices_nonce', 'nonce' );
+
+		// Check super-admin permission.
+		$super_admin = new SuperAdminService();
+		if ( ! $super_admin->isCurrentUserSuperAdmin() ) {
+			wp_send_json_error( array( 'message' => __( 'Permission denied.', 'ihumbak-invoices' ) ) );
+		}
+
+		$settings      = Plugin::get_instance()->get_settings();
+		$reset_monthly = $settings['numbering']['reset_monthly'] ?? true;
+
+		$types  = array( 'invoice', 'receipt', 'credit_note', 'receipt_return' );
+		$states = array();
+
+		foreach ( $types as $type ) {
+			$state           = $this->numbering_service->getCounterState( $type, $reset_monthly );
+			$states[ $type ] = array(
+				'label'        => $this->get_document_type_label( $type ),
+				'current_next' => $state['next_number'],
+				'last_number'  => $state['last_number'],
+				'year'         => $state['year'],
+				'month'        => $state['month'],
+				'min_allowed'  => 1,
+			);
+		}
+
+		wp_send_json_success( $states );
+	}
+
+	/**
+	 * Adjust numbering counter for a document type.
+	 *
+	 * Allows super-admins to manually set the next document number.
+	 *
+	 * @return void
+	 */
+	public function adjust_numbering(): void {
+		check_ajax_referer( 'ihumbak_invoices_nonce', 'nonce' );
+
+		// Check super-admin permission.
+		$super_admin = new SuperAdminService();
+		if ( ! $super_admin->isCurrentUserSuperAdmin() ) {
+			wp_send_json_error( array( 'message' => __( 'Only super-admins can adjust numbering.', 'ihumbak-invoices' ) ) );
+		}
+
+		$document_type = isset( $_POST['document_type'] ) ? sanitize_text_field( wp_unslash( $_POST['document_type'] ) ) : '';
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- absint sanitizes.
+		$next_number = isset( $_POST['next_number'] ) ? absint( wp_unslash( $_POST['next_number'] ) ) : 0;
+
+		// Validate document type.
+		$valid_types = array( 'invoice', 'receipt', 'credit_note', 'receipt_return' );
+		if ( ! in_array( $document_type, $valid_types, true ) ) {
+			wp_send_json_error( array( 'message' => __( 'Invalid document type.', 'ihumbak-invoices' ) ) );
+		}
+
+		// Validate next_number (must be at least 1).
+		if ( $next_number < 1 ) {
+			wp_send_json_error( array( 'message' => __( 'Next number must be at least 1.', 'ihumbak-invoices' ) ) );
+		}
+
+		// Set last_number = next_number - 1.
+		$settings      = Plugin::get_instance()->get_settings();
+		$reset_monthly = $settings['numbering']['reset_monthly'] ?? true;
+
+		$result = $this->numbering_service->setLastNumber(
+			$document_type,
+			$next_number - 1,
+			$reset_monthly
+		);
+
+		if ( $result ) {
+			wp_send_json_success(
+				array(
+					'message'     => __( 'Counter adjusted successfully.', 'ihumbak-invoices' ),
+					'next_number' => $next_number,
+				)
+			);
+		} else {
+			wp_send_json_error( array( 'message' => __( 'Failed to adjust counter.', 'ihumbak-invoices' ) ) );
+		}
+	}
+
+	/**
+	 * Get human-readable label for document type.
+	 *
+	 * @param string $type Document type key.
+	 * @return string Translated label.
+	 */
+	private function get_document_type_label( string $type ): string {
+		$labels = array(
+			'invoice'        => __( 'Invoice', 'ihumbak-invoices' ),
+			'receipt'        => __( 'Receipt', 'ihumbak-invoices' ),
+			'credit_note'    => __( 'Credit Note', 'ihumbak-invoices' ),
+			'receipt_return' => __( 'Receipt Return', 'ihumbak-invoices' ),
+		);
+
+		return $labels[ $type ] ?? $type;
 	}
 }

--- a/src/Modules/Invoice/NumberingService.php
+++ b/src/Modules/Invoice/NumberingService.php
@@ -239,4 +239,118 @@ class NumberingService {
 			default          => 'DOC/{YYYY}/{MM}/{NNNN}',
 		};
 	}
+
+	/**
+	 * Get counter state for a document type.
+	 *
+	 * Returns information about the current numbering counter state
+	 * including last number used, next number that will be assigned,
+	 * and the year/month context.
+	 *
+	 * @param string $document_type Document type (invoice, receipt, credit_note, receipt_return).
+	 * @param bool   $reset_monthly Whether numbering resets monthly.
+	 * @return array{last_number: int, next_number: int, year: int, month: int|null}
+	 */
+	public function getCounterState( string $document_type, bool $reset_monthly = true ): array {
+		$year  = (int) gmdate( 'Y' );
+		$month = $reset_monthly ? (int) gmdate( 'n' ) : null;
+		$last  = $this->getLastNumber( $document_type, $year, $month );
+
+		return array(
+			'last_number' => $last,
+			'next_number' => $last + 1,
+			'year'        => $year,
+			'month'       => $month,
+		);
+	}
+
+	/**
+	 * Set the last used number for a document type.
+	 *
+	 * This allows manual adjustment of the numbering counter, typically
+	 * used when documents are deleted after being issued and the admin
+	 * wants to reclaim the number to avoid gaps.
+	 *
+	 * @param string $document_type Document type (invoice, receipt, credit_note, receipt_return).
+	 * @param int    $last_number   The new last number value (next will be last+1).
+	 * @param bool   $reset_monthly Whether numbering resets monthly.
+	 * @return bool True on success, false on failure.
+	 */
+	public function setLastNumber( string $document_type, int $last_number, bool $reset_monthly = true ): bool {
+		$year  = (int) gmdate( 'Y' );
+		$month = $reset_monthly ? (int) gmdate( 'n' ) : null;
+
+		// Get current last number for the action hook.
+		$old_last_number = $this->getLastNumber( $document_type, $year, $month );
+
+		// Build WHERE clause.
+		$where = $this->wpdb->prepare(
+			'document_type = %s AND year = %d',
+			$document_type,
+			$year
+		);
+
+		if ( null !== $month ) {
+			$where .= $this->wpdb->prepare( ' AND month = %d', $month );
+		} else {
+			$where .= ' AND month IS NULL';
+		}
+
+		// Check if row exists.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$row = $this->wpdb->get_row(
+			"SELECT id FROM {$this->table} WHERE {$where}",
+			ARRAY_A
+		);
+
+		if ( $row ) {
+			// Update existing counter.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$result = $this->wpdb->update(
+				$this->table,
+				array( 'last_number' => $last_number ),
+				array( 'id' => $row['id'] ),
+				array( '%d' ),
+				array( '%d' )
+			);
+		} else {
+			// Insert new counter.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$result = $this->wpdb->insert(
+				$this->table,
+				array(
+					'document_type' => $document_type,
+					'year'          => $year,
+					'month'         => $month,
+					'last_number'   => $last_number,
+					'pattern'       => self::getDefaultPattern( $document_type ),
+				),
+				array( '%s', '%d', '%d', '%d', '%s' )
+			);
+		}
+
+		if ( false !== $result ) {
+			/**
+			 * Fires when a document numbering counter is manually adjusted.
+			 *
+			 * @since 0.5.7
+			 *
+			 * @param string $document_type Document type that was adjusted.
+			 * @param int    $old_number    Previous last number value.
+			 * @param int    $new_number    New last number value.
+			 * @param int    $user_id       ID of the user who made the adjustment.
+			 */
+			do_action(
+				'ihumbak_numbering_adjusted',
+				$document_type,
+				$old_last_number,
+				$last_number,
+				get_current_user_id()
+			);
+
+			return true;
+		}
+
+		return false;
+	}
 }

--- a/src/Modules/Invoice/NumberingService.php
+++ b/src/Modules/Invoice/NumberingService.php
@@ -115,17 +115,7 @@ class NumberingService {
 
 		try {
 			// Build WHERE clause.
-			$where = $this->wpdb->prepare(
-				'document_type = %s AND year = %d',
-				$document_type,
-				$year
-			);
-
-			if ( null !== $month ) {
-				$where .= $this->wpdb->prepare( ' AND month = %d', $month );
-			} else {
-				$where .= ' AND month IS NULL';
-			}
+			$where = $this->buildWhereClause( $document_type, $year, $month );
 
 			// Use SELECT ... FOR UPDATE for row-level locking (if supported).
             // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -178,6 +168,24 @@ class NumberingService {
 	 * @return int
 	 */
 	private function getLastNumber( string $document_type, int $year, ?int $month ): int {
+		$where = $this->buildWhereClause( $document_type, $year, $month );
+
+		$last_number = $this->wpdb->get_var(
+			"SELECT last_number FROM {$this->table} WHERE {$where}"
+		);
+
+		return (int) ( $last_number ?? 0 );
+	}
+
+	/**
+	 * Build WHERE clause for document type and period.
+	 *
+	 * @param string   $document_type Document type.
+	 * @param int      $year          Year.
+	 * @param int|null $month         Month (null if not resetting monthly).
+	 * @return string WHERE clause (without WHERE keyword).
+	 */
+	private function buildWhereClause( string $document_type, int $year, ?int $month ): string {
 		$where = $this->wpdb->prepare(
 			'document_type = %s AND year = %d',
 			$document_type,
@@ -190,11 +198,7 @@ class NumberingService {
 			$where .= ' AND month IS NULL';
 		}
 
-		$last_number = $this->wpdb->get_var(
-			"SELECT last_number FROM {$this->table} WHERE {$where}"
-		);
-
-		return (int) ( $last_number ?? 0 );
+		return $where;
 	}
 
 	/**
@@ -277,6 +281,11 @@ class NumberingService {
 	 * @return bool True on success, false on failure.
 	 */
 	public function setLastNumber( string $document_type, int $last_number, bool $reset_monthly = true ): bool {
+		// Validate last_number is non-negative.
+		if ( $last_number < 0 ) {
+			return false;
+		}
+
 		$year  = (int) gmdate( 'Y' );
 		$month = $reset_monthly ? (int) gmdate( 'n' ) : null;
 
@@ -284,17 +293,7 @@ class NumberingService {
 		$old_last_number = $this->getLastNumber( $document_type, $year, $month );
 
 		// Build WHERE clause.
-		$where = $this->wpdb->prepare(
-			'document_type = %s AND year = %d',
-			$document_type,
-			$year
-		);
-
-		if ( null !== $month ) {
-			$where .= $this->wpdb->prepare( ' AND month = %d', $month );
-		} else {
-			$where .= ' AND month IS NULL';
-		}
+		$where = $this->buildWhereClause( $document_type, $year, $month );
 
 		// Check if row exists.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching

--- a/templates/admin/settings.php
+++ b/templates/admin/settings.php
@@ -142,6 +142,30 @@ $active_tab = isset( $_GET['tab'] ) ? sanitize_text_field( wp_unslash( $_GET['ta
                 </tr>
             </table>
 
+            <?php
+            $super_admin_service = new \IHumbak\Invoices\Modules\Invoice\SuperAdminService();
+            if ( $super_admin_service->isCurrentUserSuperAdmin() ) :
+            ?>
+            <h2><?php esc_html_e( 'Counter Adjustment', 'ihumbak-invoices' ); ?></h2>
+            <p class="description">
+                <?php esc_html_e( 'Adjust the next document number. Use when documents were deleted after being reverted to draft.', 'ihumbak-invoices' ); ?>
+            </p>
+
+            <div class="notice notice-warning inline" style="margin: 10px 0;">
+                <p>
+                    <strong><?php esc_html_e( 'Warning:', 'ihumbak-invoices' ); ?></strong>
+                    <?php esc_html_e( 'Changing these values may cause numbering gaps or duplicates. Use with caution.', 'ihumbak-invoices' ); ?>
+                </p>
+            </div>
+
+            <table class="form-table" id="ihumbak-numbering-adjustment">
+                <tbody>
+                    <!-- Populated via JavaScript -->
+                </tbody>
+            </table>
+            <p id="ihumbak-numbering-loading"><?php esc_html_e( 'Loading...', 'ihumbak-invoices' ); ?></p>
+            <?php endif; ?>
+
         <?php elseif ( 'pdf' === $active_tab ) : ?>
             <?php
             $template_registry   = \IHumbak\Invoices\Core\Plugin::get_instance()->container()->get( 'pdf.template_registry' );


### PR DESCRIPTION
## Summary

- Add super-admin feature to manually adjust document numbering counters in Settings > Numbering tab
- This allows reclaiming numbers when documents are deleted after being reverted to draft, preventing unnecessary gaps in document numbering
- Includes audit hook `ihumbak_numbering_adjusted` for logging counter changes

## Changes

### `src/Modules/Invoice/NumberingService.php`
- Add `getCounterState()` method - returns current counter state (last_number, next_number, year, month)
- Add `setLastNumber()` method - allows setting the last used number for a document type
- Add `ihumbak_numbering_adjusted` action hook for audit logging

### `src/Modules/Admin/AjaxController.php`
- Add `wp_ajax_ihumbak_get_numbering_state` - retrieves counter states for all document types
- Add `wp_ajax_ihumbak_adjust_numbering` - adjusts counter for a document type
- Both endpoints require super-admin permission

### `templates/admin/settings.php`
- Add "Counter Adjustment" section in Numbering tab (visible only to super-admins)
- Includes warning notice about implications

### `assets/js/admin.js`
- Add `counterAdjustmentHandler` module for AJAX-based counter management
- Input validation and confirmation dialogs

### `src/Core/Plugin.php`
- Add i18n strings for counter adjustment UI

## Security

- All operations require `SuperAdminService::isCurrentUserSuperAdmin()`
- All AJAX requests verify `ihumbak_invoices_nonce` nonce
- Document type validated against whitelist
- Next number must be positive integer

## Test plan

- [ ] Configure super-admin in wp-config.php: `define('IHUMBAK_SUPER_ADMIN_IDS', '1');`
- [ ] Go to Settings > Numbering tab
- [ ] Verify "Counter Adjustment" section appears (only for super-admin)
- [ ] Test adjusting counter values for each document type
- [ ] Verify non-super-admin users don't see the section
- [ ] Test validation (try entering 0 or negative number)

🤖 Generated with [Claude Code](https://claude.com/claude-code)